### PR TITLE
금칙어 예외 처리 추가

### DIFF
--- a/src/main/java/com/recipe/app/common/exception/BaseException.java
+++ b/src/main/java/com/recipe/app/common/exception/BaseException.java
@@ -12,8 +12,8 @@ public class BaseException extends RuntimeException {
         this.status = status;
     }
 
-    public BaseException(BaseResponseStatus status, String ingredientName) {
-        super(status.getMessage(ingredientName));
+    public BaseException(BaseResponseStatus status, String word) {
+        super(status.getMessage(word));
         this.status = status;
     }
 }

--- a/src/main/java/com/recipe/app/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/recipe/app/common/response/BaseResponseStatus.java
@@ -211,6 +211,8 @@ public enum BaseResponseStatus {
 
     FRIDGE_SAVE_UNIT_NOT_MATCH(3080, "냉장고에 존재하는 재료(%s)의 단위와 냉장고 바구니의 재료 단위가 일치하지 않습니다"),
 
+    BAD_WORD_CONTAIN(3081, "금칙어 설정된 단어(%s)를 포함하고 있습니다."),
+
     /**
      * 4000 : Database, Server 오류
      */

--- a/src/main/java/com/recipe/app/src/common/application/BadWordService.java
+++ b/src/main/java/com/recipe/app/src/common/application/BadWordService.java
@@ -1,0 +1,27 @@
+package com.recipe.app.src.common.application;
+
+import com.recipe.app.src.common.domain.BadWords;
+import com.recipe.app.src.common.exception.BadWordException;
+import com.recipe.app.src.common.mapper.BadWordsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BadWordService {
+
+    private final BadWordsRepository badWordsRepository;
+
+    public void checkBadWords(String keyword) {
+        List<String> badWords = badWordsRepository.findByWordContaining(keyword).stream()
+                .map(BadWords::getWord)
+                .collect(Collectors.toList());
+        if (badWords.size() > 0)
+            throw new BadWordException(badWords.toString());
+    }
+}

--- a/src/main/java/com/recipe/app/src/common/domain/BadWords.java
+++ b/src/main/java/com/recipe/app/src/common/domain/BadWords.java
@@ -1,0 +1,19 @@
+package com.recipe.app.src.common.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@EqualsAndHashCode(callSuper = false)
+@Data
+@Entity
+@Table(name = "BadWords")
+public class BadWords {
+    @Id
+    @Column(name = "word", nullable = false, updatable = false)
+    private String word;
+}

--- a/src/main/java/com/recipe/app/src/common/exception/BadWordException.java
+++ b/src/main/java/com/recipe/app/src/common/exception/BadWordException.java
@@ -1,0 +1,10 @@
+package com.recipe.app.src.common.exception;
+
+import com.recipe.app.common.exception.BaseException;
+import com.recipe.app.common.response.BaseResponseStatus;
+
+public class BadWordException extends BaseException {
+    public BadWordException(String word) {
+        super(BaseResponseStatus.BAD_WORD_CONTAIN, word);
+    }
+}

--- a/src/main/java/com/recipe/app/src/common/mapper/BadWordsRepository.java
+++ b/src/main/java/com/recipe/app/src/common/mapper/BadWordsRepository.java
@@ -1,0 +1,13 @@
+package com.recipe.app.src.common.mapper;
+
+import com.recipe.app.src.common.domain.BadWords;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BadWordsRepository extends CrudRepository<BadWords, String> {
+
+    List<BadWords> findByWordContaining(String keyword);
+}

--- a/src/main/java/com/recipe/app/src/fridgeBasket/api/FridgeBasketController.java
+++ b/src/main/java/com/recipe/app/src/fridgeBasket/api/FridgeBasketController.java
@@ -1,6 +1,7 @@
 package com.recipe.app.src.fridgeBasket.api;
 
 import com.recipe.app.common.response.BaseResponse;
+import com.recipe.app.src.common.application.BadWordService;
 import com.recipe.app.src.fridgeBasket.application.FridgeBasketService;
 import com.recipe.app.src.fridgeBasket.application.dto.FridgeBasketDto;
 import com.recipe.app.src.fridgeBasket.domain.FridgeBasket;
@@ -26,6 +27,7 @@ import static com.recipe.app.common.response.BaseResponse.success;
 public class FridgeBasketController {
 
     private final FridgeBasketService fridgeBasketService;
+    private final BadWordService badWordService;
 
     @ApiOperation(value = "재료 선택하여 냉장고 바구니 채우기 API")
     @ResponseBody
@@ -55,6 +57,7 @@ public class FridgeBasketController {
             throw new UserTokenNotExistException();
 
         User user = ((SecurityUser) authentication.getPrincipal()).getUser();
+        badWordService.checkBadWords(request.getIngredientName());
         List<FridgeBasket> fridgeBaskets = fridgeBasketService.createFridgeBasketWithIngredientSave(user, request);
         FridgeBasketDto.FridgeBasketsResponse data = FridgeBasketDto.FridgeBasketsResponse.from(fridgeBaskets);
 

--- a/src/main/java/com/recipe/app/src/recipe/api/BlogRecipeController.java
+++ b/src/main/java/com/recipe/app/src/recipe/api/BlogRecipeController.java
@@ -1,6 +1,7 @@
 package com.recipe.app.src.recipe.api;
 
 import com.recipe.app.common.response.BaseResponse;
+import com.recipe.app.src.common.application.BadWordService;
 import com.recipe.app.src.recipe.application.BlogRecipeService;
 import com.recipe.app.src.recipe.application.SearchKeywordService;
 import com.recipe.app.src.recipe.application.dto.RecipeDto;
@@ -28,6 +29,7 @@ import static com.recipe.app.common.response.BaseResponse.success;
 public class BlogRecipeController {
 
     private final BlogRecipeService blogRecipeService;
+    private final BadWordService badWordService;
     private final SearchKeywordService recipeKeywordService;
 
     @ApiOperation(value = "블로그 레시피 목록 조회 API")
@@ -46,6 +48,7 @@ public class BlogRecipeController {
             throw new UserTokenNotExistException();
 
         User user = ((SecurityUser) authentication.getPrincipal()).getUser();
+        badWordService.checkBadWords(keyword);
         Page<BlogRecipe> blogRecipes = blogRecipeService.getBlogRecipes(keyword, page, size, sort);
         if (blogRecipes.getTotalElements() < 10) {
             blogRecipes = blogRecipeService.searchNaverBlogRecipes(keyword, page, size, sort);

--- a/src/main/java/com/recipe/app/src/recipe/api/RecipeController.java
+++ b/src/main/java/com/recipe/app/src/recipe/api/RecipeController.java
@@ -180,6 +180,8 @@ public class RecipeController {
             throw new UserTokenNotExistException();
 
         User user = ((SecurityUser) authentication.getPrincipal()).getUser();
+        badWordService.checkBadWords(request.getTitle());
+        badWordService.checkBadWords(request.getContent());
         recipeService.createRecipe(user, request);
 
         return success();
@@ -195,6 +197,8 @@ public class RecipeController {
             throw new UserTokenNotExistException();
 
         User user = ((SecurityUser) authentication.getPrincipal()).getUser();
+        badWordService.checkBadWords(request.getTitle());
+        badWordService.checkBadWords(request.getContent());
         recipeService.updateRecipe(user, recipeId, request);
 
         return success();

--- a/src/main/java/com/recipe/app/src/recipe/api/RecipeController.java
+++ b/src/main/java/com/recipe/app/src/recipe/api/RecipeController.java
@@ -1,6 +1,7 @@
 package com.recipe.app.src.recipe.api;
 
 import com.recipe.app.common.response.BaseResponse;
+import com.recipe.app.src.common.application.BadWordService;
 import com.recipe.app.src.fridge.application.FridgeService;
 import com.recipe.app.src.fridge.domain.Fridge;
 import com.recipe.app.src.recipe.application.RecipeService;
@@ -36,6 +37,7 @@ public class RecipeController {
     private final RecipeService recipeService;
     private final SearchKeywordService recipeKeywordService;
     private final FridgeService fridgeService;
+    private final BadWordService badWordService;
 
     @ApiOperation(value = "레시피 목록 조회 API")
     @GetMapping("")
@@ -53,6 +55,7 @@ public class RecipeController {
             throw new UserTokenNotExistException();
 
         User user = ((SecurityUser) authentication.getPrincipal()).getUser();
+        badWordService.checkBadWords(keyword);
         Page<Recipe> recipes = recipeService.getRecipes(keyword, page, size, sort);
         RecipeDto.RecipesResponse data = new RecipeDto.RecipesResponse(recipes.getTotalElements(), recipes.stream()
                 .map((recipe) -> RecipeDto.RecipeResponse.from(recipe, user))

--- a/src/main/java/com/recipe/app/src/recipe/api/YoutubeRecipeController.java
+++ b/src/main/java/com/recipe/app/src/recipe/api/YoutubeRecipeController.java
@@ -1,6 +1,7 @@
 package com.recipe.app.src.recipe.api;
 
 import com.recipe.app.common.response.BaseResponse;
+import com.recipe.app.src.common.application.BadWordService;
 import com.recipe.app.src.recipe.application.SearchKeywordService;
 import com.recipe.app.src.recipe.application.YoutubeRecipeService;
 import com.recipe.app.src.recipe.application.dto.RecipeDto;
@@ -29,6 +30,7 @@ public class YoutubeRecipeController {
 
     private final YoutubeRecipeService youtubeRecipeService;
     private final SearchKeywordService recipeKeywordService;
+    private final BadWordService badWordService;
 
     @ApiOperation(value = "유튜브 레시피 목록 조회 API")
     @GetMapping("")
@@ -46,6 +48,7 @@ public class YoutubeRecipeController {
             throw new UserTokenNotExistException();
 
         User user = ((SecurityUser) authentication.getPrincipal()).getUser();
+        badWordService.checkBadWords(keyword);
         Page<YoutubeRecipe> youtubeRecipes = youtubeRecipeService.getYoutubeRecipes(keyword, page, size, sort);
         if (youtubeRecipes.getTotalElements() < 10)
             youtubeRecipes = youtubeRecipeService.searchYoutubes(keyword, page, size, sort);

--- a/src/main/java/com/recipe/app/src/recipe/infra/keyword/SearchKeywordJpaRepository.java
+++ b/src/main/java/com/recipe/app/src/recipe/infra/keyword/SearchKeywordJpaRepository.java
@@ -7,6 +7,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface SearchKeywordJpaRepository extends CrudRepository<SearchKeywordEntity, Long> {
-    @Query(value = "select * from SearchKeyword sk where sk.createdAt between :startDTime and :endDTime group by sk.keyword order by count(*) desc limit 10;", nativeQuery = true)
+    @Query(value = "select * from SearchKeyword sk " +
+            "left join BadWords b on sk.keyword like concat('%', b.word, '%')" +
+            "where b.word is null and sk.createdAt between :startDTime and :endDTime " +
+            "group by sk.keyword order by count(*) desc limit 10;", nativeQuery = true)
     List<SearchKeywordEntity> findSearchKeywordsTop10(LocalDateTime startDTime, LocalDateTime endDTime);
 }

--- a/src/main/java/com/recipe/app/src/user/api/UserController.java
+++ b/src/main/java/com/recipe/app/src/user/api/UserController.java
@@ -2,6 +2,7 @@ package com.recipe.app.src.user.api;
 
 import com.recipe.app.common.response.BaseResponse;
 import com.recipe.app.common.utils.JwtService;
+import com.recipe.app.src.common.application.BadWordService;
 import com.recipe.app.src.recipe.application.BlogRecipeService;
 import com.recipe.app.src.recipe.application.RecipeService;
 import com.recipe.app.src.recipe.application.YoutubeRecipeService;
@@ -41,6 +42,7 @@ public class UserController {
     private final RecipeService recipeService;
     private final YoutubeRecipeService youtubeRecipeService;
     private final BlogRecipeService blogRecipeService;
+    private final BadWordService badWordService;
     private final JwtService jwtService;
 
     @Value("${header.naver-token}")
@@ -190,6 +192,7 @@ public class UserController {
             throw new UserTokenNotExistException();
 
         User user = ((SecurityUser) authentication.getPrincipal()).getUser();
+        badWordService.checkBadWords(request.getNickname());
         user = userService.updateUser(user, request);
         long youtubeScrapCnt = youtubeRecipeService.countYoutubeScrapByUser(user);
         long blogScrapCnt = blogRecipeService.countBlogScrapByUser(user);


### PR DESCRIPTION
## Issue Number

#35 

## Summary

- 닉네임 수정 시 금칙어 예외 처리
- 재료 직접 입력 시 금칙어 예외 처리
- 레시피 등록 및 수정 시 금칙어 예외 처리
- 인기 검색어 조회 시 금칙어 제외 조회
- 레시피 검색 시 금칙어 예외 처리

## Describe

- 등록 및 수정 시에 금칙어 확인하도록 추가
- 해당하는 금칙어가 무엇인지 전달하도록 처리
- 인기 검색어 조회 시에도 금칙어 존재하면 조회되지 않도록 처리
- 레시피 검색 시에도 아무래도 API 불필요한 호출 줄이기 위해서 금칙어 예외 처리 추가

## ETC

- 레시피 재료 직접 입력의 경우가 빠져있어서 기능 추가 후 재료명 금칙어 예외 처리 추가 예정