### PR TITLE
fix: 레시피 등록 및 수정 시 레시피 직접 입력 가능하도록 수정

### DIFF
--- a/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeDto.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeDto.java
@@ -34,9 +34,15 @@ public class RecipeDto {
     @AllArgsConstructor
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class RecipeIngredientRequest {
-        @Schema(description = "재료 고유 번호")
+        @Schema(description = "재료 고유 번호 (재료 선택 시 추가, 직접 재료 입력 시 null)", nullable = true)
         private Long ingredientId;
-        @Schema(description = "레시피 재료 용량")
+        @Schema(description = "레시피 재료명 (직접 재료 입력 시 추가, 재료 선택 시 null)", nullable = true)
+        private String ingredientName;
+        @Schema(description = "레시피 재료 아이콘 url (직접 재료 입력 시 추가, 재료 선택 시 null)", nullable = true)
+        private String ingredientIconUrl;
+        @Schema(description = "레시피 재료 카테고리 고유 번호 (직접 재료 입력 시 추가, 재료 선택 시 null)", nullable = true)
+        private Long ingredientCategoryId;
+        @Schema(description = "레시피 재료 용량", nullable = true)
         private String capacity;
     }
 


### PR DESCRIPTION
## Issue Number

#24 

## Summary

- 레시피 등록 및 수정 시 레시피 직접 입력 가능하도록 수정

## Describe

- 재료 직접 입력 시 재료 요청 DTO 값 변경
  -  재료 고유 번호 null
  - 재료명 추가
  - 재료 아이콘 url 추가
  - 재료 카테고리 아이디 추가
- 레시피 등록 및 수정 시 재료 고유번호가 null인 경우에는 재료 새로 추가하고 레시피 재료로 등록하도록 처리

## ETC

-
