### PR TITLE
fix: 네이버, 카카오, 구글 로그인 시 access token과 fcm token을 header가 아닌 request body로 받도록 수정

### DIFF
--- a/src/main/java/com/recipe/app/src/user/api/UserController.java
+++ b/src/main/java/com/recipe/app/src/user/api/UserController.java
@@ -82,14 +82,14 @@ public class UserController {
     @ApiOperation(value = "네이버 로그인 API")
     @ResponseBody
     @PostMapping("/naver-login")
-    public BaseResponse<UserDto.UserProfileResponse> naverLogin(HttpServletRequest request) throws IOException, ParseException {
+    public BaseResponse<UserDto.UserProfileResponse> naverLogin(@RequestBody UserDto.UserLoginRequest request) throws IOException, ParseException {
 
-        String accessToken = request.getHeader(this.naverToken);
+        String accessToken = request.getAccessToken();
         if (!StringUtils.hasText(accessToken)) {
             throw new EmptyTokenException();
         }
 
-        String fcmToken = request.getHeader(this.fcmToken);
+        String fcmToken = request.getFcmToken();
         if (!StringUtils.hasText(fcmToken)) {
             throw new EmptyFcmTokenException();
         }
@@ -110,14 +110,14 @@ public class UserController {
     @ApiOperation(value = "카카오 로그인 API")
     @ResponseBody
     @PostMapping("/kakao-login")
-    public BaseResponse<UserDto.UserProfileResponse> kakaoLogin(HttpServletRequest request) throws IOException, ParseException {
+    public BaseResponse<UserDto.UserProfileResponse> kakaoLogin(@RequestBody UserDto.UserLoginRequest request) throws IOException, ParseException {
 
-        String accessToken = request.getHeader(this.kakaoToken);
+        String accessToken = request.getAccessToken();
         if (!StringUtils.hasText(accessToken)) {
             throw new EmptyTokenException();
         }
 
-        String fcmToken = request.getHeader(this.fcmToken);
+        String fcmToken = request.getFcmToken();
         if (!StringUtils.hasText(fcmToken)) {
             throw new EmptyFcmTokenException();
         }
@@ -138,14 +138,14 @@ public class UserController {
     @ApiOperation(value = "구글 로그인 API")
     @ResponseBody
     @PostMapping("/google-login")
-    public BaseResponse<UserDto.UserProfileResponse> googleLogin(HttpServletRequest request) throws IOException, ParseException {
+    public BaseResponse<UserDto.UserProfileResponse> googleLogin(@RequestBody UserDto.UserLoginRequest request) throws IOException, ParseException {
 
-        String accessToken = request.getHeader(this.googleToken);
+        String accessToken = request.getAccessToken();
         if (!StringUtils.hasText(accessToken)) {
             throw new EmptyTokenException();
         }
 
-        String fcmToken = request.getHeader(this.fcmToken);
+        String fcmToken = request.getFcmToken();
         if (!StringUtils.hasText(fcmToken)) {
             throw new EmptyFcmTokenException();
         }

--- a/src/main/java/com/recipe/app/src/user/api/UserController.java
+++ b/src/main/java/com/recipe/app/src/user/api/UserController.java
@@ -45,18 +45,6 @@ public class UserController {
     private final BadWordService badWordService;
     private final JwtService jwtService;
 
-    @Value("${header.naver-token}")
-    private String naverToken;
-
-    @Value("${header.kakao-token}")
-    private String kakaoToken;
-
-    @Value("${header.google-token}")
-    private String googleToken;
-
-    @Value("${header.fcm-token}")
-    private String fcmToken;
-
     @Value("${jwt.token-header}")
     private String jwt;
 

--- a/src/main/java/com/recipe/app/src/user/application/dto/UserDto.java
+++ b/src/main/java/com/recipe/app/src/user/application/dto/UserDto.java
@@ -14,6 +14,18 @@ import java.util.stream.Collectors;
 
 public class UserDto {
 
+    @ApiModel(description = "로그인 토큰 정보 요청 DTO")
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserLoginRequest {
+        @ApiModelProperty(value = "로그인 액세스 토큰")
+        private String accessToken;
+        @ApiModelProperty(value = "FCM 토큰")
+        private String fcmToken;
+    }
+
     @ApiModel(value = "수정할 회원 정보 요청 DTO", description = "프로필 사진, 닉네임 정보")
     @Getter
     @Setter


### PR DESCRIPTION
## Issue Number

#24 

## Summary

- 네이버, 카카오, 구글 로그인 시 전달받는 access token 값을 Header 가 아닌 request body로 받도록 수정

## Describe

- 전역 헤더의 경우 swagger에서 확인 가능하지만 특정 api에서 받는 경우 표시가 되지 않아 혼동 가능성 있었음
- jwt 의 경우 전역 헤더로 그대로 상요하고 로그인 api 에 필요한 각 액세스 토큰 값은 request body로 받도록 수정

## ETC
