### PR TITLE
fix: 소셜 로그인 시 jwt값 헤더가 아니라 response body에 포함되도록 수정

### DIFF
--- a/src/main/java/com/recipe/app/src/user/api/UserController.java
+++ b/src/main/java/com/recipe/app/src/user/api/UserController.java
@@ -70,7 +70,7 @@ public class UserController {
     @ApiOperation(value = "네이버 로그인 API")
     @ResponseBody
     @PostMapping("/naver-login")
-    public BaseResponse<UserDto.UserProfileResponse> naverLogin(@RequestBody UserDto.UserLoginRequest request) throws IOException, ParseException {
+    public BaseResponse<UserDto.UserSocialProfileResponse> naverLogin(@RequestBody UserDto.UserLoginRequest request) throws IOException, ParseException {
 
         String accessToken = request.getAccessToken();
         if (!StringUtils.hasText(accessToken)) {
@@ -83,14 +83,12 @@ public class UserController {
         }
 
         User user = userService.naverLogin(accessToken, fcmToken);
-        HttpHeaders httpHeaders = new HttpHeaders();
         String jwt = jwtService.createJwt(user.getUserId());
-        httpHeaders.add(this.jwt, jwt);
         long youtubeScrapCnt = youtubeRecipeService.countYoutubeScrapByUser(user);
         long blogScrapCnt = blogRecipeService.countBlogScrapByUser(user);
         long recipeScrapCnt = recipeService.countRecipeScrapByUser(user);
         List<Recipe> userRecipes = recipeService.getRecipesByUser(user, 0 , 6).toList();
-        UserDto.UserProfileResponse data = UserDto.UserProfileResponse.from(user, userRecipes, youtubeScrapCnt, blogScrapCnt, recipeScrapCnt);
+        UserDto.UserSocialProfileResponse data = UserDto.UserSocialProfileResponse.from(user, jwt, userRecipes, youtubeScrapCnt, blogScrapCnt, recipeScrapCnt);
 
         return success(data);
     }
@@ -98,7 +96,7 @@ public class UserController {
     @ApiOperation(value = "카카오 로그인 API")
     @ResponseBody
     @PostMapping("/kakao-login")
-    public BaseResponse<UserDto.UserProfileResponse> kakaoLogin(@RequestBody UserDto.UserLoginRequest request) throws IOException, ParseException {
+    public BaseResponse<UserDto.UserSocialProfileResponse> kakaoLogin(@RequestBody UserDto.UserLoginRequest request) throws IOException, ParseException {
 
         String accessToken = request.getAccessToken();
         if (!StringUtils.hasText(accessToken)) {
@@ -111,14 +109,12 @@ public class UserController {
         }
 
         User user = userService.kakaoLogin(accessToken, fcmToken);
-        HttpHeaders httpHeaders = new HttpHeaders();
         String jwt = jwtService.createJwt(user.getUserId());
-        httpHeaders.add(this.jwt, jwt);
         long youtubeScrapCnt = youtubeRecipeService.countYoutubeScrapByUser(user);
         long blogScrapCnt = blogRecipeService.countBlogScrapByUser(user);
         long recipeScrapCnt = recipeService.countRecipeScrapByUser(user);
         List<Recipe> userRecipes = recipeService.getRecipesByUser(user, 0, 6).toList();
-        UserDto.UserProfileResponse data = UserDto.UserProfileResponse.from(user, userRecipes, youtubeScrapCnt, blogScrapCnt, recipeScrapCnt);
+        UserDto.UserSocialProfileResponse data = UserDto.UserSocialProfileResponse.from(user, jwt, userRecipes, youtubeScrapCnt, blogScrapCnt, recipeScrapCnt);
 
         return success(data);
     }
@@ -126,7 +122,7 @@ public class UserController {
     @ApiOperation(value = "구글 로그인 API")
     @ResponseBody
     @PostMapping("/google-login")
-    public BaseResponse<UserDto.UserProfileResponse> googleLogin(@RequestBody UserDto.UserLoginRequest request) throws IOException, ParseException {
+    public BaseResponse<UserDto.UserSocialProfileResponse> googleLogin(@RequestBody UserDto.UserLoginRequest request) throws IOException, ParseException {
 
         String accessToken = request.getAccessToken();
         if (!StringUtils.hasText(accessToken)) {
@@ -139,14 +135,12 @@ public class UserController {
         }
 
         User user = userService.googleLogin(accessToken, fcmToken);
-        HttpHeaders httpHeaders = new HttpHeaders();
         String jwt = jwtService.createJwt(user.getUserId());
-        httpHeaders.add(this.jwt, jwt);
         long youtubeScrapCnt = youtubeRecipeService.countYoutubeScrapByUser(user);
         long blogScrapCnt = blogRecipeService.countBlogScrapByUser(user);
         long recipeScrapCnt = recipeService.countRecipeScrapByUser(user);
         List<Recipe> userRecipes = recipeService.getRecipesByUser(user, 0, 6).toList();
-        UserDto.UserProfileResponse data = UserDto.UserProfileResponse.from(user, userRecipes, youtubeScrapCnt, blogScrapCnt, recipeScrapCnt);
+        UserDto.UserSocialProfileResponse data = UserDto.UserSocialProfileResponse.from(user, jwt, userRecipes, youtubeScrapCnt, blogScrapCnt, recipeScrapCnt);
 
         return success(data);
     }

--- a/src/main/java/com/recipe/app/src/user/application/dto/UserDto.java
+++ b/src/main/java/com/recipe/app/src/user/application/dto/UserDto.java
@@ -48,6 +48,22 @@ public class UserDto {
         private String fcmToken;
     }
 
+    @Schema(description = "jwt와 회원 프로필 응답 DTO")
+    @Getter
+    @Builder
+    public static class UserSocialProfileResponse {
+        @Schema(description = "jwt")
+        private String jwt;
+        private UserProfileResponse userProfile;
+
+        public static UserSocialProfileResponse from(User user, String jwt, List<Recipe> userRecipes, long youtubeScrapCnt, long blogScrapCnt, long recipeScrapCnt) {
+            return UserSocialProfileResponse.builder()
+                    .jwt(jwt)
+                    .userProfile(UserProfileResponse.from(user, userRecipes, youtubeScrapCnt, blogScrapCnt, recipeScrapCnt))
+                    .build();
+        }
+    }
+
     @Schema(description = "회원 프로필 응답 DTO")
     @Getter
     @Builder


### PR DESCRIPTION
## Issue Number

#24 

## Summary

- 소셜 로그인 시 jwt값 헤더가 아니라 response body에 포함되도록 수정

## Describe

- 클라이언트에서 jwt값을 받을 때는 header로 받는 게 맞으나 백엔드에서 보낼 때는 header로 보낼 필요 있는 건 아님
- 기존에 jwt값을 response body로 보내고 있었으므로 유지하는 게 나을 것 같았음
- response body에서 header로 jwt 전달하는 경우 swagger로 어떻게 추가해줘야 할지에 대한 고민이 생김
- 소셜 로그인 시에만 dto에 jwt값을 추가로 전달하도록 수정함

## ETC

- 참고 : https://velog.io/@hiy7030/Spring-Security-JWT-Token