### PR TITLE
fix: 냉장고 응답값 중 카테고리 목록 이름을 fridges 중복되는 문제 수정

### DIFF
--- a/src/main/java/com/recipe/app/src/fridge/application/dto/FridgeDto.java
+++ b/src/main/java/com/recipe/app/src/fridge/application/dto/FridgeDto.java
@@ -32,7 +32,7 @@ public class FridgeDto {
     @Builder
     public static class FridgesResponse {
         @Schema(description = "카테고리별 냉장고 목록")
-        private List<FridgeIngredientCategoryResponse> fridges;
+        private List<FridgeIngredientCategoryResponse> fridgeIngredientCategories;
         @Schema(description = "냉장고 바구니 갯수")
         private long fridgeBasketCount;
 
@@ -40,7 +40,7 @@ public class FridgeDto {
             Map<IngredientCategory, List<Fridge>> fridgesGroupByIngredientCategory = fridges.stream()
                     .collect(Collectors.groupingBy(f -> f.getIngredient().getIngredientCategory()));
             return FridgesResponse.builder()
-                    .fridges(fridgesGroupByIngredientCategory.keySet().stream()
+                    .fridgeIngredientCategories(fridgesGroupByIngredientCategory.keySet().stream()
                             .map(category -> FridgeIngredientCategoryResponse.from(category, fridges))
                             .collect(Collectors.toList()))
                     .fridgeBasketCount(fridgeBasketCount)


### PR DESCRIPTION
## Issue Number

#24

## Summary

- 냉장고 목록 조회 응답값 중 중복명칭 변경

## Describe

- 카테고리별로 묶은 응답값이므로 fridges 에서 fridgeIngredientCategories로 변경하여 명확성 높임

## ETC

- 