### PR TITLE
fix: expiredAt 응답값을 String 에서 ZonedlDateTime으로 변경

### DIFF
--- a/src/main/java/com/recipe/app/src/fridge/application/dto/FridgeDto.java
+++ b/src/main/java/com/recipe/app/src/fridge/application/dto/FridgeDto.java
@@ -6,7 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -25,6 +26,10 @@ public class FridgeDto {
         private float quantity;
         @Schema(description = "단위")
         private String unit;
+
+        public LocalDateTime getExpiredAt() {
+            return this.expiredAt.atTime(LocalTime.MIN);
+        }
     }
 
     @Schema(description = "냉장고 목록 응답 DTO")
@@ -81,7 +86,7 @@ public class FridgeDto {
         @Schema(description = "재료 아이콘 url")
         private String ingredientIconUrl;
         @Schema(description = "유통기한")
-        private String expiredAt;
+        private LocalDateTime expiredAt;
         @Schema(description = "수량")
         private float quantity;
         @Schema(description = "단위")
@@ -94,7 +99,7 @@ public class FridgeDto {
                     .fridgeId(fridge.getFridgeId())
                     .ingredientName(fridge.getIngredient().getIngredientName())
                     .ingredientIconUrl(fridge.getIngredient().getIngredientIconUrl())
-                    .expiredAt(fridge.getExpiredAt() != null ? fridge.getExpiredAt().format(DateTimeFormatter.ofPattern("yy.MM.dd 까지")) : null)
+                    .expiredAt(fridge.getExpiredAt())
                     .quantity(fridge.getQuantity())
                     .unit(fridge.getUnit())
                     .freshness(fridge.getFreshness().getName())

--- a/src/main/java/com/recipe/app/src/fridge/application/dto/FridgeDto.java
+++ b/src/main/java/com/recipe/app/src/fridge/application/dto/FridgeDto.java
@@ -8,6 +8,8 @@ import lombok.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -86,7 +88,7 @@ public class FridgeDto {
         @Schema(description = "재료 아이콘 url")
         private String ingredientIconUrl;
         @Schema(description = "유통기한")
-        private LocalDateTime expiredAt;
+        private ZonedDateTime expiredAt;
         @Schema(description = "수량")
         private float quantity;
         @Schema(description = "단위")
@@ -99,7 +101,7 @@ public class FridgeDto {
                     .fridgeId(fridge.getFridgeId())
                     .ingredientName(fridge.getIngredient().getIngredientName())
                     .ingredientIconUrl(fridge.getIngredient().getIngredientIconUrl())
-                    .expiredAt(fridge.getExpiredAt())
+                    .expiredAt(fridge.getExpiredAt() != null ? fridge.getExpiredAt().atZone(ZoneId.of("Asia/Seoul")) : null)
                     .quantity(fridge.getQuantity())
                     .unit(fridge.getUnit())
                     .freshness(fridge.getFreshness().getName())

--- a/src/main/java/com/recipe/app/src/fridge/domain/Fridge.java
+++ b/src/main/java/com/recipe/app/src/fridge/domain/Fridge.java
@@ -16,14 +16,14 @@ public class Fridge {
     private final Long fridgeId;
     private final User user;
     private final Ingredient ingredient;
-    private final LocalDate expiredAt;
+    private final LocalDateTime expiredAt;
     private final float quantity;
     private final String unit;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
     @Builder
-    public Fridge(Long fridgeId, User user, Ingredient ingredient, LocalDate expiredAt, float quantity, String unit, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public Fridge(Long fridgeId, User user, Ingredient ingredient, LocalDateTime expiredAt, float quantity, String unit, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.fridgeId = fridgeId;
         this.user = user;
         this.ingredient = ingredient;
@@ -61,7 +61,7 @@ public class Fridge {
         return Freshness.FRESH;
     }
 
-    public Fridge changeExpiredAtAndQuantityAndUnit(LocalDate expiredAt, float quantity, String unit) {
+    public Fridge changeExpiredAtAndQuantityAndUnit(LocalDateTime expiredAt, float quantity, String unit) {
         LocalDateTime now = LocalDateTime.now();
         return Fridge.builder()
                 .fridgeId(fridgeId)

--- a/src/main/java/com/recipe/app/src/fridge/infra/FridgeEntity.java
+++ b/src/main/java/com/recipe/app/src/fridge/infra/FridgeEntity.java
@@ -10,7 +10,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @EqualsAndHashCode(callSuper = false)
@@ -32,7 +32,7 @@ public class FridgeEntity extends BaseEntity {
     private IngredientEntity ingredient;
 
     @Column(name = "expiredAt")
-    private LocalDate expiredAt;
+    private LocalDateTime expiredAt;
 
     @Column(name = "quantity", nullable = false)
     private float quantity;

--- a/src/main/java/com/recipe/app/src/fridgeBasket/application/dto/FridgeBasketDto.java
+++ b/src/main/java/com/recipe/app/src/fridgeBasket/application/dto/FridgeBasketDto.java
@@ -6,7 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -49,6 +50,10 @@ public class FridgeBasketDto {
         private float quantity;
         @Schema(description = "단위")
         private String unit;
+
+        public LocalDateTime getExpiredAt() {
+            return this.expiredAt.atTime(LocalTime.MIN);
+        }
     }
 
     @Schema(description = "냉장고 바구니 목록 응답 DTO")
@@ -105,7 +110,7 @@ public class FridgeBasketDto {
         @Schema(description = "냉장고 바구니 재료 아이콘 url")
         private String ingredientIconUrl;
         @Schema(description = "냉장고 바구니 재료 유통 기한")
-        private String expiredAt;
+        private LocalDateTime expiredAt;
         @Schema(description = "냉장고 바구니 재료 수량")
         private float quantity;
         @Schema(description = "냉장고 바구니 재료 단위")
@@ -116,7 +121,7 @@ public class FridgeBasketDto {
                     .fridgeBasketId(fridgeBasket.getFridgeBasketId())
                     .ingredientName(fridgeBasket.getIngredient().getIngredientName())
                     .ingredientIconUrl(fridgeBasket.getIngredient().getIngredientIconUrl())
-                    .expiredAt(fridgeBasket.getExpiredAt() != null ? fridgeBasket.getExpiredAt().format(DateTimeFormatter.ofPattern("yy.MM.dd")) : null)
+                    .expiredAt(fridgeBasket.getExpiredAt())
                     .quantity(fridgeBasket.getQuantity())
                     .unit(fridgeBasket.getUnit())
                     .build();

--- a/src/main/java/com/recipe/app/src/fridgeBasket/application/dto/FridgeBasketDto.java
+++ b/src/main/java/com/recipe/app/src/fridgeBasket/application/dto/FridgeBasketDto.java
@@ -8,6 +8,8 @@ import lombok.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -110,7 +112,7 @@ public class FridgeBasketDto {
         @Schema(description = "냉장고 바구니 재료 아이콘 url")
         private String ingredientIconUrl;
         @Schema(description = "냉장고 바구니 재료 유통 기한")
-        private LocalDateTime expiredAt;
+        private ZonedDateTime expiredAt;
         @Schema(description = "냉장고 바구니 재료 수량")
         private float quantity;
         @Schema(description = "냉장고 바구니 재료 단위")
@@ -121,7 +123,7 @@ public class FridgeBasketDto {
                     .fridgeBasketId(fridgeBasket.getFridgeBasketId())
                     .ingredientName(fridgeBasket.getIngredient().getIngredientName())
                     .ingredientIconUrl(fridgeBasket.getIngredient().getIngredientIconUrl())
-                    .expiredAt(fridgeBasket.getExpiredAt())
+                    .expiredAt(fridgeBasket.getExpiredAt() != null ? fridgeBasket.getExpiredAt().atZone(ZoneId.of("Asia/Seoul")) : null)
                     .quantity(fridgeBasket.getQuantity())
                     .unit(fridgeBasket.getUnit())
                     .build();

--- a/src/main/java/com/recipe/app/src/fridgeBasket/domain/FridgeBasket.java
+++ b/src/main/java/com/recipe/app/src/fridgeBasket/domain/FridgeBasket.java
@@ -5,7 +5,6 @@ import com.recipe.app.src.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -14,14 +13,14 @@ public class FridgeBasket {
     private final Long fridgeBasketId;
     private final User user;
     private final Ingredient ingredient;
-    private final LocalDate expiredAt;
+    private final LocalDateTime expiredAt;
     private final float quantity;
     private final String unit;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
     @Builder
-    public FridgeBasket(Long fridgeBasketId, User user, Ingredient ingredient, LocalDate expiredAt, float quantity, String unit, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public FridgeBasket(Long fridgeBasketId, User user, Ingredient ingredient, LocalDateTime expiredAt, float quantity, String unit, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.fridgeBasketId = fridgeBasketId;
         this.user = user;
         this.ingredient = ingredient;
@@ -58,7 +57,7 @@ public class FridgeBasket {
                 .build();
     }
 
-    public FridgeBasket changeExpiredAtAndQuantityAndUnit(LocalDate expiredAt, float quantity, String unit) {
+    public FridgeBasket changeExpiredAtAndQuantityAndUnit(LocalDateTime expiredAt, float quantity, String unit) {
         LocalDateTime now = LocalDateTime.now();
         return FridgeBasket.builder()
                 .fridgeBasketId(fridgeBasketId)

--- a/src/main/java/com/recipe/app/src/fridgeBasket/infra/FridgeBasketEntity.java
+++ b/src/main/java/com/recipe/app/src/fridgeBasket/infra/FridgeBasketEntity.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @EqualsAndHashCode(callSuper = false)
@@ -33,7 +34,7 @@ public class FridgeBasketEntity extends BaseEntity {
     private IngredientEntity ingredient;
 
     @Column(name = "expiredAt")
-    private LocalDate expiredAt;
+    private LocalDateTime expiredAt;
 
     @Column(name = "quantity", nullable = false)
     private float quantity = 1;


### PR DESCRIPTION
## Issue Number

-

## Summary

- expiredAt을 'yyyy.M.d까지'란 String 타입에서 iso8061 기준 ZonedDateTime 으로 변경

## Describe

- 

## ETC

-
