### PR TITLE
fix: mixed content 에러 해결

### DIFF
--- a/src/main/webapp/WEB-INF/views/user-withdrawal.jsp
+++ b/src/main/webapp/WEB-INF/views/user-withdrawal.jsp
@@ -11,7 +11,7 @@
     <title>탈퇴하기</title>
 </head>
 <body>
-<script src="http://code.jquery.com/jquery-latest.js"></script>
+<script src="https://code.jquery.com/jquery-latest.js"></script>
 <script type="text/javascript">
     function withdraw() {
         $.ajax({

--- a/src/main/webapp/WEB-INF/views/user-withdrawal.jsp
+++ b/src/main/webapp/WEB-INF/views/user-withdrawal.jsp
@@ -6,6 +6,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <link href="/static/css/style.css" rel="stylesheet" type="text/css">
     <title>탈퇴하기</title>
 </head>


### PR DESCRIPTION
## Issue Number

-

## Summary

- mixed content 에러 해결

## Describe

- 회원탈퇴 버튼 클릭 시 mixed content 에러 발생

## ETC

```
Mixed Content: The page at 'https://recipestoragetest2023.shop:9090/users/auth/kakao/callback?code=EKC9l6st12RHKJtuQcIs1Swou1tNkggMHYemlKDk_dIXAutG4rU_NX4XjLoKKiUPAAABjrIYhWf_A_o_BVb6-Q' was loaded over HTTPS, but requested an insecure script 'http://code.jquery.com/jquery-latest.js'. This request has been blocked; the content must be served over HTTPS.
```
