### PR TITLE
fix: 냉장고 파먹기 레시피 조회 시 재료 일치도 계산 오류 수정

### DIFF
--- a/src/main/java/com/recipe/app/src/recipe/application/RecipeService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/RecipeService.java
@@ -259,7 +259,7 @@ public class RecipeService {
                                     || ingredientNamesInFridge.contains(ingredient.getIngredientName()))
                             .count();
 
-                    return recipeIngredientInFridgeCnt / recipeIngredientCnt * 100;
+                    return (long) ((double) recipeIngredientInFridgeCnt / recipeIngredientCnt * 100);
                 }));
     }
 


### PR DESCRIPTION
## Issue Number

-

## Summary

- 냉장고 파먹기 레시피 조회 시 재료 일치도 계산 오류 수정

## Describe

- 재료 일치도 값이 전부 0으로 계산되는 문제 발생
- double 값으로 계산 후 변환하도록 수정

## ETC

-
