### PR TITLE
Feature/fix ingredient icon

### DIFF
--- a/src/main/java/com/recipe/app/src/fridge/application/dto/FridgeResponse.java
+++ b/src/main/java/com/recipe/app/src/fridge/application/dto/FridgeResponse.java
@@ -1,6 +1,5 @@
 package com.recipe.app.src.fridge.application.dto;
 
-import com.recipe.app.src.fridge.domain.Freshness;
 import com.recipe.app.src.fridge.domain.Fridge;
 import com.recipe.app.src.ingredient.domain.Ingredient;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,8 +18,8 @@ public class FridgeResponse {
     private final Long fridgeId;
     @Schema(description = "재료명")
     private final String ingredientName;
-    @Schema(description = "재료 아이콘 url")
-    private final String ingredientIconUrl;
+    @Schema(description = "재료 아이콘 고유 번호")
+    private final Long ingredientIconId;
     @Schema(description = "유통기한")
     private final ZonedDateTime expiredAt;
     @Schema(description = "수량")
@@ -31,11 +30,11 @@ public class FridgeResponse {
     private final String freshness;
 
     @Builder
-    public FridgeResponse(Long fridgeId, String ingredientName, String ingredientIconUrl, ZonedDateTime expiredAt, float quantity, String unit, String freshness) {
+    public FridgeResponse(Long fridgeId, String ingredientName, Long ingredientIconId, ZonedDateTime expiredAt, float quantity, String unit, String freshness) {
 
         this.fridgeId = fridgeId;
         this.ingredientName = ingredientName;
-        this.ingredientIconUrl = ingredientIconUrl;
+        this.ingredientIconId = ingredientIconId;
         this.expiredAt = expiredAt;
         this.quantity = quantity;
         this.unit = unit;
@@ -46,7 +45,7 @@ public class FridgeResponse {
         return FridgeResponse.builder()
                 .fridgeId(fridge.getFridgeId())
                 .ingredientName(ingredient.getIngredientName())
-                .ingredientIconUrl(ingredient.getIngredientIconUrl())
+                .ingredientIconId(ingredient.getIngredientIconId())
                 .expiredAt(fridge.getExpiredAt() != null ? fridge.getExpiredAt().atTime(LocalTime.MIN).atZone(ZoneId.of("Asia/Seoul")) : null)
                 .quantity(fridge.getQuantity())
                 .unit(fridge.getUnit())

--- a/src/main/java/com/recipe/app/src/fridgeBasket/application/FridgeBasketService.java
+++ b/src/main/java/com/recipe/app/src/fridgeBasket/application/FridgeBasketService.java
@@ -75,15 +75,15 @@ public class FridgeBasketService {
         badWordService.checkBadWords(request.getIngredientName());
 
         IngredientCategory ingredientCategory = ingredientCategoryService.findById(request.getIngredientCategoryId());
-        Ingredient ingredient = ingredientService.findByUserIdAndIngredientNameAndIngredientIconUrlAndIngredientCategoryId(
+        Ingredient ingredient = ingredientService.findByUserIdAndIngredientNameAndIngredientIconIdAndIngredientCategoryId(
                         user.getUserId(),
                         request.getIngredientName(),
-                        request.getIngredientIconUrl(),
+                        request.getIngredientIconId(),
                         ingredientCategory.getIngredientCategoryId())
                 .orElseGet(() -> Ingredient.builder()
                         .userId(user.getUserId())
                         .ingredientName(request.getIngredientName())
-                        .ingredientIconUrl(request.getIngredientIconUrl())
+                        .ingredientIconId(request.getIngredientIconId())
                         .ingredientCategoryId(ingredientCategory.getIngredientCategoryId())
                         .build());
         ingredientService.createIngredient(ingredient);

--- a/src/main/java/com/recipe/app/src/fridgeBasket/application/dto/FridgeBasketIngredientRequest.java
+++ b/src/main/java/com/recipe/app/src/fridgeBasket/application/dto/FridgeBasketIngredientRequest.java
@@ -12,8 +12,8 @@ public class FridgeBasketIngredientRequest {
 
     @Schema(description = "재료명")
     private String ingredientName;
-    @Schema(description = "재료 아이콘 url")
-    private String ingredientIconUrl;
+    @Schema(description = "재료 아이콘 고유 번호")
+    private Long ingredientIconId;
     @Schema(description = "재료 카테고리 고유 번호")
     private Long ingredientCategoryId;
 }

--- a/src/main/java/com/recipe/app/src/fridgeBasket/application/dto/FridgeBasketResponse.java
+++ b/src/main/java/com/recipe/app/src/fridgeBasket/application/dto/FridgeBasketResponse.java
@@ -1,6 +1,5 @@
 package com.recipe.app.src.fridgeBasket.application.dto;
 
-import com.recipe.app.src.fridge.domain.Freshness;
 import com.recipe.app.src.fridgeBasket.domain.FridgeBasket;
 import com.recipe.app.src.ingredient.domain.Ingredient;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -20,7 +19,7 @@ public class FridgeBasketResponse {
     @Schema(description = "냉장고 바구니 재료명")
     private final String ingredientName;
     @Schema(description = "냉장고 바구니 재료 아이콘 url")
-    private final String ingredientIconUrl;
+    private final Long ingredientIconId;
     @Schema(description = "냉장고 바구니 재료 유통 기한")
     private final ZonedDateTime expiredAt;
     @Schema(description = "냉장고 바구니 재료 수량")
@@ -31,11 +30,11 @@ public class FridgeBasketResponse {
     private final String freshness;
 
     @Builder
-    public FridgeBasketResponse(Long fridgeBasketId, String ingredientName, String ingredientIconUrl, ZonedDateTime expiredAt, float quantity, String unit, String freshness) {
+    public FridgeBasketResponse(Long fridgeBasketId, String ingredientName, Long ingredientIconId, ZonedDateTime expiredAt, float quantity, String unit, String freshness) {
 
         this.fridgeBasketId = fridgeBasketId;
         this.ingredientName = ingredientName;
-        this.ingredientIconUrl = ingredientIconUrl;
+        this.ingredientIconId = ingredientIconId;
         this.expiredAt = expiredAt;
         this.quantity = quantity;
         this.unit = unit;
@@ -46,7 +45,7 @@ public class FridgeBasketResponse {
         return FridgeBasketResponse.builder()
                 .fridgeBasketId(fridgeBasket.getFridgeBasketId())
                 .ingredientName(ingredient.getIngredientName())
-                .ingredientIconUrl(ingredient.getIngredientIconUrl())
+                .ingredientIconId(ingredient.getIngredientIconId())
                 .expiredAt(fridgeBasket.getExpiredAt() != null ? fridgeBasket.getExpiredAt().atTime(LocalTime.MIN).atZone(ZoneId.of("Asia/Seoul")) : null)
                 .quantity(fridgeBasket.getQuantity())
                 .unit(fridgeBasket.getUnit())

--- a/src/main/java/com/recipe/app/src/ingredient/api/IngredientController.java
+++ b/src/main/java/com/recipe/app/src/ingredient/api/IngredientController.java
@@ -2,6 +2,8 @@ package com.recipe.app.src.ingredient.api;
 
 import com.recipe.app.common.response.BaseResponse;
 import com.recipe.app.src.ingredient.application.IngredientFacadeService;
+import com.recipe.app.src.ingredient.application.IngredientService;
+import com.recipe.app.src.ingredient.application.dto.IngredientRequest;
 import com.recipe.app.src.ingredient.application.dto.IngredientsResponse;
 import com.recipe.app.src.user.domain.SecurityUser;
 import com.recipe.app.src.user.domain.User;
@@ -12,6 +14,8 @@ import io.swagger.annotations.ApiParam;
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,9 +29,11 @@ import static com.recipe.app.common.response.BaseResponse.success;
 public class IngredientController {
 
     private final IngredientFacadeService ingredientFacadeService;
+    private final IngredientService ingredientService;
 
-    public IngredientController(IngredientFacadeService ingredientFacadeService) {
+    public IngredientController(IngredientFacadeService ingredientFacadeService, IngredientService ingredientService) {
         this.ingredientFacadeService = ingredientFacadeService;
+        this.ingredientService = ingredientService;
     }
 
     @ApiOperation(value = "재료 목록 조회 API")
@@ -42,5 +48,21 @@ public class IngredientController {
         User user = ((SecurityUser) authentication.getPrincipal()).getUser();
 
         return success(ingredientFacadeService.findIngredientsByKeyword(user, keyword));
+    }
+
+    @ApiOperation(value = "재료 등록 API")
+    @PostMapping("")
+    public BaseResponse<Void> postIngredient(@ApiIgnore final Authentication authentication,
+                                             @ApiParam(value = "재료 추가 정보", required = true)
+                                             @RequestBody IngredientRequest request) {
+
+        if (authentication == null)
+            throw new UserTokenNotExistException();
+
+        User user = ((SecurityUser) authentication.getPrincipal()).getUser();
+
+        ingredientService.createIngredient(user.getUserId(), request);
+
+        return success();
     }
 }

--- a/src/main/java/com/recipe/app/src/ingredient/application/IngredientFacadeService.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/IngredientFacadeService.java
@@ -29,7 +29,7 @@ public class IngredientFacadeService {
 
         long fridgeBasketCount = fridgeBasketService.countByUserId(user.getUserId());
         List<IngredientCategory> categories = ingredientCategoryService.findAll();
-        List<Ingredient> ingredients = ingredientService.findByKeyword(keyword);
+        List<Ingredient> ingredients = ingredientService.findByKeyword(user.getUserId(), keyword);
 
         return IngredientsResponse.from(fridgeBasketCount, categories, ingredients);
     }

--- a/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
@@ -22,13 +22,13 @@ public class IngredientService {
     }
 
     @Transactional(readOnly = true)
-    public List<Ingredient> findByKeyword(String keyword) {
+    public List<Ingredient> findByKeyword(Long userId, String keyword) {
 
         if (!StringUtils.hasText(keyword)) {
-            return ingredientRepository.findDefaultIngredients();
+            return ingredientRepository.findDefaultIngredients(userId);
         }
 
-        return ingredientRepository.findDefaultIngredientsByKeyword(keyword);
+        return ingredientRepository.findDefaultIngredientsByKeyword(userId, keyword);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
@@ -1,6 +1,8 @@
 package com.recipe.app.src.ingredient.application;
 
+import com.recipe.app.src.ingredient.application.dto.IngredientRequest;
 import com.recipe.app.src.ingredient.domain.Ingredient;
+import com.recipe.app.src.ingredient.domain.IngredientCategory;
 import com.recipe.app.src.ingredient.exception.NotFoundIngredientException;
 import com.recipe.app.src.ingredient.infra.IngredientRepository;
 import com.recipe.app.src.user.domain.User;
@@ -15,10 +17,12 @@ import java.util.Optional;
 @Service
 public class IngredientService {
 
+    private final IngredientCategoryService ingredientCategoryService;
     private final IngredientRepository ingredientRepository;
 
-    public IngredientService(IngredientRepository ingredientRepository) {
+    public IngredientService(IngredientRepository ingredientRepository, IngredientCategoryService ingredientCategoryService) {
         this.ingredientRepository = ingredientRepository;
+        this.ingredientCategoryService = ingredientCategoryService;
     }
 
     @Transactional(readOnly = true)
@@ -45,6 +49,25 @@ public class IngredientService {
 
     @Transactional
     public void createIngredient(Ingredient ingredient) {
+        ingredientRepository.save(ingredient);
+    }
+
+    @Transactional
+    public void createIngredient(Long userId, IngredientRequest request) {
+
+        IngredientCategory ingredientCategory = ingredientCategoryService.findById(request.getIngredientCategoryId());
+        Ingredient ingredient = ingredientRepository.findByUserIdAndIngredientNameAndIngredientIconIdAndIngredientCategoryId(
+                        userId,
+                        request.getIngredientName(),
+                        request.getIngredientIconId(),
+                        ingredientCategory.getIngredientCategoryId())
+                .orElseGet(() -> Ingredient.builder()
+                        .userId(userId)
+                        .ingredientName(request.getIngredientName())
+                        .ingredientIconId(request.getIngredientIconId())
+                        .ingredientCategoryId(ingredientCategory.getIngredientCategoryId())
+                        .build());
+
         ingredientRepository.save(ingredient);
     }
 

--- a/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
@@ -38,9 +38,9 @@ public class IngredientService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<Ingredient> findByUserIdAndIngredientNameAndIngredientIconUrlAndIngredientCategoryId(Long userId, String ingredientName, String ingredientIconUrl, Long ingredientCategoryId) {
+    public Optional<Ingredient> findByUserIdAndIngredientNameAndIngredientIconIdAndIngredientCategoryId(Long userId, String ingredientName, Long ingredientIconId, Long ingredientCategoryId) {
 
-        return ingredientRepository.findByUserIdAndIngredientNameAndIngredientIconUrlAndIngredientCategoryId(userId, ingredientName, ingredientIconUrl, ingredientCategoryId);
+        return ingredientRepository.findByUserIdAndIngredientNameAndIngredientIconIdAndIngredientCategoryId(userId, ingredientName, ingredientIconId, ingredientCategoryId);
     }
 
     @Transactional

--- a/src/main/java/com/recipe/app/src/ingredient/application/dto/IngredientRequest.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/dto/IngredientRequest.java
@@ -1,0 +1,18 @@
+package com.recipe.app.src.ingredient.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "재료 추가 요청 DTO")
+@Getter
+@NoArgsConstructor
+public class IngredientRequest {
+
+    @Schema(description = "재료명")
+    private String ingredientName;
+    @Schema(description = "재료 아이콘 고유 번호")
+    private Long ingredientIconId;
+    @Schema(description = "재료 카테고리 고유 번호")
+    private Long ingredientCategoryId;
+}

--- a/src/main/java/com/recipe/app/src/ingredient/application/dto/IngredientResponse.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/dto/IngredientResponse.java
@@ -13,15 +13,15 @@ public class IngredientResponse {
     private final Long ingredientId;
     @Schema(description = "재료명")
     private final String ingredientName;
-    @Schema(description = "재료 아이콘 url")
-    private final String ingredientIconUrl;
+    @Schema(description = "재료 아이콘 아이디")
+    private final Long ingredientIconId;
 
     @Builder
-    public IngredientResponse(Long ingredientId, String ingredientName, String ingredientIconUrl) {
+    public IngredientResponse(Long ingredientId, String ingredientName, Long ingredientIconId) {
 
         this.ingredientId = ingredientId;
         this.ingredientName = ingredientName;
-        this.ingredientIconUrl = ingredientIconUrl;
+        this.ingredientIconId = ingredientIconId;
     }
 
     public static IngredientResponse from(Ingredient ingredient) {
@@ -29,7 +29,7 @@ public class IngredientResponse {
         return IngredientResponse.builder()
                 .ingredientId(ingredient.getIngredientId())
                 .ingredientName(ingredient.getIngredientName())
-                .ingredientIconUrl(ingredient.getIngredientIconUrl())
+                .ingredientIconId(ingredient.getIngredientIconId())
                 .build();
     }
 }

--- a/src/main/java/com/recipe/app/src/ingredient/domain/Ingredient.java
+++ b/src/main/java/com/recipe/app/src/ingredient/domain/Ingredient.java
@@ -31,14 +31,14 @@ public class Ingredient extends BaseEntity {
     @Column(name = "ingredientName", nullable = false, length = 64)
     private String ingredientName;
 
-    @Column(name = "ingredientIconUrl")
-    private String ingredientIconUrl;
+    @Column(name = "ingredientIconId")
+    private Long ingredientIconId;
 
     @Column(name = "userId")
     private Long userId;
 
     @Builder
-    public Ingredient(Long ingredientId, Long ingredientCategoryId, String ingredientName, String ingredientIconUrl, Long userId) {
+    public Ingredient(Long ingredientId, Long ingredientCategoryId, String ingredientName, Long ingredientIconId, Long userId) {
 
         Objects.requireNonNull(ingredientCategoryId, "재료 카테고리 아이디를 입력해주세요.");
         Preconditions.checkArgument(StringUtils.hasText(ingredientName), "재료명을 입력해주세요.");
@@ -46,7 +46,7 @@ public class Ingredient extends BaseEntity {
         this.ingredientId = ingredientId;
         this.ingredientCategoryId = ingredientCategoryId;
         this.ingredientName = ingredientName;
-        this.ingredientIconUrl = ingredientIconUrl;
+        this.ingredientIconId = ingredientIconId;
         this.userId = userId;
     }
 

--- a/src/main/java/com/recipe/app/src/ingredient/infra/IngredientCustomRepository.java
+++ b/src/main/java/com/recipe/app/src/ingredient/infra/IngredientCustomRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface IngredientCustomRepository {
 
-    List<Ingredient> findDefaultIngredientsByKeyword(String keyword);
+    List<Ingredient> findDefaultIngredientsByKeyword(Long userId, String keyword);
 
-    List<Ingredient> findDefaultIngredients();
+    List<Ingredient> findDefaultIngredients(Long userId);
 }

--- a/src/main/java/com/recipe/app/src/ingredient/infra/IngredientRepository.java
+++ b/src/main/java/com/recipe/app/src/ingredient/infra/IngredientRepository.java
@@ -11,7 +11,7 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long>, I
 
     List<Ingredient> findByIngredientIdIn(Collection<Long> ingredientIds);
 
-    Optional<Ingredient> findByUserIdAndIngredientNameAndIngredientIconUrlAndIngredientCategoryId(Long userId, String ingredientName, String ingredientIconUrl, Long ingredientCategoryId);
+    Optional<Ingredient> findByUserIdAndIngredientNameAndIngredientIconIdAndIngredientCategoryId(Long userId, String ingredientName, Long ingredientIconId, Long ingredientCategoryId);
 
     List<Ingredient> findByUserId(Long userId);
 }

--- a/src/main/java/com/recipe/app/src/ingredient/infra/IngredientRepositoryImpl.java
+++ b/src/main/java/com/recipe/app/src/ingredient/infra/IngredientRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.recipe.app.src.ingredient.infra;
 
 import com.recipe.app.common.infra.BaseRepositoryImpl;
 import com.recipe.app.src.ingredient.domain.Ingredient;
-import com.recipe.app.src.ingredient.domain.QIngredient;
 
 import javax.persistence.EntityManager;
 import java.util.List;

--- a/src/main/java/com/recipe/app/src/ingredient/infra/IngredientRepositoryImpl.java
+++ b/src/main/java/com/recipe/app/src/ingredient/infra/IngredientRepositoryImpl.java
@@ -15,24 +15,30 @@ public class IngredientRepositoryImpl extends BaseRepositoryImpl implements Ingr
     }
 
     @Override
-    public List<Ingredient> findDefaultIngredientsByKeyword(String keyword) {
+    public List<Ingredient> findDefaultIngredientsByKeyword(Long userId, String keyword) {
 
         return queryFactory
                 .selectFrom(ingredient)
                 .where(
-                        ingredient.userId.isNull(),
+                        (ingredient.ingredientCategoryId.ne(7L)
+                                .and(ingredient.userId.isNull().or(ingredient.userId.eq(userId))))
+                                .or(ingredient.ingredientCategoryId.eq(7L)
+                                        .and(ingredient.userId.eq(userId))),
                         ingredient.ingredientName.contains(keyword)
                 )
                 .fetch();
     }
 
     @Override
-    public List<Ingredient> findDefaultIngredients() {
+    public List<Ingredient> findDefaultIngredients(Long userId) {
 
         return queryFactory
                 .selectFrom(ingredient)
                 .where(
-                        ingredient.userId.isNull()
+                        (ingredient.ingredientCategoryId.ne(7L)
+                                .and(ingredient.userId.isNull().or(ingredient.userId.eq(userId))))
+                                .or(ingredient.ingredientCategoryId.eq(7L)
+                                        .and(ingredient.userId.eq(userId)))
                 )
                 .fetch();
     }

--- a/src/main/java/com/recipe/app/src/recipe/application/RecipeIngredientService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/RecipeIngredientService.java
@@ -53,7 +53,7 @@ public class RecipeIngredientService {
                 .collect(Collectors.toMap(recipeIngredient -> Ingredient.builder()
                                 .ingredientCategoryId(recipeIngredient.getIngredientCategoryId())
                                 .ingredientName(recipeIngredient.getIngredientName())
-                                .ingredientIconUrl(recipeIngredient.getIngredientIconUrl())
+                                .ingredientIconId(recipeIngredient.getIngredientIconId())
                                 .userId(user.getUserId())
                                 .build(),
                         RecipeIngredientRequest::getCapacity));

--- a/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeIngredientRequest.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeIngredientRequest.java
@@ -14,8 +14,8 @@ public class RecipeIngredientRequest {
     private Long ingredientId;
     @Schema(description = "레시피 재료명 (직접 재료 입력 시 추가, 재료 선택 시 null)", nullable = true)
     private String ingredientName;
-    @Schema(description = "레시피 재료 아이콘 url (직접 재료 입력 시 추가, 재료 선택 시 null)", nullable = true)
-    private String ingredientIconUrl;
+    @Schema(description = "레시피 재료 아이콘 고유 번호 (직접 재료 입력 시 추가, 재료 선택 시 null)", nullable = true)
+    private Long ingredientIconId;
     @Schema(description = "레시피 재료 카테고리 고유 번호 (직접 재료 입력 시 추가, 재료 선택 시 null)", nullable = true)
     private Long ingredientCategoryId;
     @Schema(description = "레시피 재료 용량", nullable = true)

--- a/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeIngredientResponse.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeIngredientResponse.java
@@ -14,20 +14,20 @@ public class RecipeIngredientResponse {
     private final Long recipeIngredientId;
     @Schema(description = "레시피 재료명")
     private final String recipeIngredientName;
-    @Schema(description = "레시피 재료 아이콘 url")
-    private final String recipeIngredientIconUrl;
+    @Schema(description = "레시피 재료 아이콘 고유 번호")
+    private final Long recipeIngredientIconId;
     @Schema(description = "레시피 재료 용량")
     private final String recipeIngredientCapacity;
     @Schema(description = "레시피 재료 냉장고 존재 여부")
     private final Boolean isInUserFridge;
 
     @Builder
-    public RecipeIngredientResponse(Long recipeIngredientId, String recipeIngredientName, String recipeIngredientIconUrl,
+    public RecipeIngredientResponse(Long recipeIngredientId, String recipeIngredientName, Long recipeIngredientIconId,
                                     String recipeIngredientCapacity, Boolean isInUserFridge) {
 
         this.recipeIngredientId = recipeIngredientId;
         this.recipeIngredientName = recipeIngredientName;
-        this.recipeIngredientIconUrl = recipeIngredientIconUrl;
+        this.recipeIngredientIconId = recipeIngredientIconId;
         this.recipeIngredientCapacity = recipeIngredientCapacity;
         this.isInUserFridge = isInUserFridge;
     }
@@ -37,7 +37,7 @@ public class RecipeIngredientResponse {
         return RecipeIngredientResponse.builder()
                 .recipeIngredientId(recipeIngredient.getRecipeIngredientId())
                 .recipeIngredientName(ingredient.getIngredientName())
-                .recipeIngredientIconUrl(ingredient.getIngredientIconUrl())
+                .recipeIngredientIconId(ingredient.getIngredientIconId())
                 .recipeIngredientCapacity(recipeIngredient.getCapacity())
                 .isInUserFridge(isInUserFridge)
                 .build();

--- a/src/main/java/com/recipe/app/src/user/api/UserController.java
+++ b/src/main/java/com/recipe/app/src/user/api/UserController.java
@@ -46,8 +46,6 @@ public class UserController {
     @PostMapping("/auto-login")
     public BaseResponse<UserLoginResponse> autoLogin(@ApiIgnore final Authentication authentication) {
 
-        System.out.println(jwtService.createJwt(18L));
-
         if (authentication == null)
             throw new UserTokenNotExistException();
 

--- a/src/main/java/com/recipe/app/src/user/api/UserController.java
+++ b/src/main/java/com/recipe/app/src/user/api/UserController.java
@@ -46,6 +46,8 @@ public class UserController {
     @PostMapping("/auto-login")
     public BaseResponse<UserLoginResponse> autoLogin(@ApiIgnore final Authentication authentication) {
 
+        System.out.println(jwtService.createJwt(18L));
+
         if (authentication == null)
             throw new UserTokenNotExistException();
 

--- a/src/test/groovy/com/recipe/app/src/ingredient/infra/IngredientCustomRepositoryTest.groovy
+++ b/src/test/groovy/com/recipe/app/src/ingredient/infra/IngredientCustomRepositoryTest.groovy
@@ -30,16 +30,19 @@ class IngredientCustomRepositoryTest extends Specification {
 
         List<Ingredient> ingredients = [
                 Ingredient.builder()
+                        .userId(1L)
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("사과")
                         .ingredientIconId(10000)
                         .build(),
                 Ingredient.builder()
+                        .userId(1L)
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("체리")
                         .ingredientIconId(10000)
                         .build(),
                 Ingredient.builder()
+                        .userId(1L)
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("블루베리")
                         .ingredientIconId(10000)
@@ -48,7 +51,7 @@ class IngredientCustomRepositoryTest extends Specification {
         ingredientRepository.saveAll(ingredients);
 
         when:
-        List<Ingredient> response = ingredientRepository.findDefaultIngredientsByKeyword("리");
+        List<Ingredient> response = ingredientRepository.findDefaultIngredientsByKeyword(1L, "리");
 
         then:
         response.size() == 2
@@ -64,16 +67,19 @@ class IngredientCustomRepositoryTest extends Specification {
 
         List<Ingredient> ingredients = [
                 Ingredient.builder()
+                        .userId(1L)
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("사과")
                         .ingredientIconId(10000)
                         .build(),
                 Ingredient.builder()
+                        .userId(1L)
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("포도")
                         .ingredientIconId(10000)
                         .build(),
                 Ingredient.builder()
+                        .userId(1L)
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("귤")
                         .ingredientIconId(10000)
@@ -82,7 +88,7 @@ class IngredientCustomRepositoryTest extends Specification {
         ingredientRepository.saveAll(ingredients);
 
         when:
-        List<Ingredient> response = ingredientRepository.findDefaultIngredients();
+        List<Ingredient> response = ingredientRepository.findDefaultIngredients(1L);
 
         then:
         response.size() == 3

--- a/src/test/groovy/com/recipe/app/src/ingredient/infra/IngredientCustomRepositoryTest.groovy
+++ b/src/test/groovy/com/recipe/app/src/ingredient/infra/IngredientCustomRepositoryTest.groovy
@@ -32,17 +32,17 @@ class IngredientCustomRepositoryTest extends Specification {
                 Ingredient.builder()
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("사과")
-                        .ingredientIconUrl("http://img.jpg")
+                        .ingredientIconId(10000)
                         .build(),
                 Ingredient.builder()
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("체리")
-                        .ingredientIconUrl("http://img.jpg")
+                        .ingredientIconId(10000)
                         .build(),
                 Ingredient.builder()
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("블루베리")
-                        .ingredientIconUrl("http://img.jpg")
+                        .ingredientIconId(10000)
                         .build(),
         ]
         ingredientRepository.saveAll(ingredients);
@@ -66,17 +66,17 @@ class IngredientCustomRepositoryTest extends Specification {
                 Ingredient.builder()
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("사과")
-                        .ingredientIconUrl("http://img.jpg")
+                        .ingredientIconId(10000)
                         .build(),
                 Ingredient.builder()
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("포도")
-                        .ingredientIconUrl("http://img.jpg")
+                        .ingredientIconId(10000)
                         .build(),
                 Ingredient.builder()
                         .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
                         .ingredientName("귤")
-                        .ingredientIconUrl("http://img.jpg")
+                        .ingredientIconId(10000)
                         .build(),
         ]
         ingredientRepository.saveAll(ingredients);


### PR DESCRIPTION
## Issue Number

-

## Summary

- 재료 아이콘 Url 대신 id값 전달하도록 수정
- 재료 추가 기능 추가
- 재료 목록 조회 시 유저 등록 재료 포함하도록 수정

## Describe

- url 전달 시보다 클라이언트에 저장된 id값을 전달하는 것이 표시 속도가 빨라질 것 같아서 수정하기로 함
- 재료의 경우 자주 업데이트가 있는 항목이 아니므로 url 자체를 저장하는 것보다 해당 방법이 나을 것 같다고 판단
- 유저가 등록한 재료를 저장하고 표시하도록 하고 재활용 가능하도록 재료 추가 기능 추가 
- 재료 추가를 하는 것을 재료 직접 입력하여 바로 냉장고 바구니에 넣는 기능 대신하도록 함

## ETC

-
