### PR TITLE
Feature/fix ingredients feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ build/
 
 nohup.out
 /logs/*
-application.yml
+application*.yml
 application-test.yml
 Secret.java
 recipeapp-key.json

--- a/src/main/java/com/recipe/app/src/fridge/application/FridgeService.java
+++ b/src/main/java/com/recipe/app/src/fridge/application/FridgeService.java
@@ -159,10 +159,11 @@ public class FridgeService {
         return ingredientService.findByIngredientIds(ingredientIds);
     }
 
-    @Transactional(readOnly = true)
-    public boolean hasIngredient(Long ingredientId) {
+    @Transactional
+    public void deleteByUserIdAndIngredientId(Long userId, Long ingredientId) {
 
-        return fridgeRepository.existsByIngredientId(ingredientId);
+        fridgeRepository.findByUserIdAndIngredientId(userId, ingredientId)
+                .ifPresent(fridgeRepository::delete);
     }
 
      /*

--- a/src/main/java/com/recipe/app/src/fridge/application/FridgeService.java
+++ b/src/main/java/com/recipe/app/src/fridge/application/FridgeService.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 public class FridgeService {
@@ -134,19 +135,19 @@ public class FridgeService {
     }
 
     @Transactional(readOnly = true)
-    public boolean isInFridge(Long userId, Ingredient ingredient) {
+    public boolean isInFridge(Long userId, String ingredientName) {
 
         List<Fridge> fridges = fridgeRepository.findByUserId(userId);
         List<Long> ingredientIds = fridges.stream()
                 .map(Fridge::getIngredientId)
                 .collect(Collectors.toList());
         List<Ingredient> ingredients = ingredientService.findByIngredientIds(ingredientIds);
-        List<String> ingredientNames = ingredients.stream()
-                .map(Ingredient::getIngredientName)
+        List<String> ingredientNamesInFridge = ingredients.stream()
+                .flatMap(ingredient -> Stream.of(ingredient.getIngredientName(), ingredient.getSimilarIngredientName()))
+                .map(Object::toString)
                 .collect(Collectors.toList());
 
-        return ingredientNames.contains(ingredient.getIngredientName())
-                || ingredient.existInIngredients(ingredients);
+        return ingredientNamesInFridge.contains(ingredientName);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/recipe/app/src/fridge/infra/FridgeRepository.java
+++ b/src/main/java/com/recipe/app/src/fridge/infra/FridgeRepository.java
@@ -13,5 +13,5 @@ public interface FridgeRepository extends JpaRepository<Fridge, Long> {
 
     Optional<Fridge> findByUserIdAndFridgeId(Long userId, Long fridgeId);
 
-    boolean existsByIngredientId(Long ingredientId);
+    Optional<Fridge> findByUserIdAndIngredientId(Long userId, Long ingredientId);
 }

--- a/src/main/java/com/recipe/app/src/fridgeBasket/application/FridgeBasketService.java
+++ b/src/main/java/com/recipe/app/src/fridgeBasket/application/FridgeBasketService.java
@@ -161,9 +161,10 @@ public class FridgeBasketService {
         return fridgeBasketRepository.findByUserId(userId);
     }
 
-    @Transactional(readOnly = true)
-    public boolean hasIngredient(Long ingredientId) {
+    @Transactional
+    public void deleteByUserIdAndIngredientId(Long userId, Long ingredientId) {
 
-        return fridgeBasketRepository.existsByIngredientId(ingredientId);
+        fridgeBasketRepository.findByIngredientIdAndUserId(ingredientId, userId)
+                .ifPresent(fridgeBasketRepository::delete);
     }
 }

--- a/src/main/java/com/recipe/app/src/fridgeBasket/infra/FridgeBasketRepository.java
+++ b/src/main/java/com/recipe/app/src/fridgeBasket/infra/FridgeBasketRepository.java
@@ -15,6 +15,4 @@ public interface FridgeBasketRepository extends JpaRepository<FridgeBasket, Long
     long countByUserId(Long userId);
 
     Optional<FridgeBasket> findByIngredientIdAndUserId(Long ingredientId, Long userId);
-
-    boolean existsByIngredientId(Long ingredientId);
 }

--- a/src/main/java/com/recipe/app/src/ingredient/api/IngredientController.java
+++ b/src/main/java/com/recipe/app/src/ingredient/api/IngredientController.java
@@ -84,7 +84,6 @@ public class IngredientController {
 
         User user = ((SecurityUser) authentication.getPrincipal()).getUser();
 
-        ingredientFacadeService.checkIngredientIsUsed(user, ingredientId);
-        ingredientService.deleteIngredient(user, ingredientId);
+        ingredientFacadeService.deleteMyIngredient(user, ingredientId);
     }
 }

--- a/src/main/java/com/recipe/app/src/ingredient/api/IngredientController.java
+++ b/src/main/java/com/recipe/app/src/ingredient/api/IngredientController.java
@@ -2,6 +2,7 @@ package com.recipe.app.src.ingredient.api;
 
 import com.recipe.app.src.ingredient.application.IngredientFacadeService;
 import com.recipe.app.src.ingredient.application.IngredientService;
+import com.recipe.app.src.ingredient.application.dto.IngredientCreateResponse;
 import com.recipe.app.src.ingredient.application.dto.IngredientRequest;
 import com.recipe.app.src.ingredient.application.dto.IngredientsResponse;
 import com.recipe.app.src.user.domain.SecurityUser;
@@ -63,8 +64,8 @@ public class IngredientController {
 
     @ApiOperation(value = "나만의 재료 등록 API")
     @PostMapping("")
-    public void postIngredient(@ApiIgnore final Authentication authentication,
-                               @ApiParam(value = "재료 추가 정보", required = true)
+    public IngredientCreateResponse postIngredient(@ApiIgnore final Authentication authentication,
+                                                   @ApiParam(value = "재료 추가 정보", required = true)
                                @RequestBody IngredientRequest request) {
 
         if (authentication == null)
@@ -72,7 +73,7 @@ public class IngredientController {
 
         User user = ((SecurityUser) authentication.getPrincipal()).getUser();
 
-        ingredientService.createIngredient(user.getUserId(), request);
+        return ingredientService.createIngredient(user.getUserId(), request);
     }
 
     @ApiOperation(value = "나만의 재료 삭제 API")

--- a/src/main/java/com/recipe/app/src/ingredient/application/IngredientFacadeService.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/IngredientFacadeService.java
@@ -49,7 +49,7 @@ public class IngredientFacadeService {
 
         long fridgeBasketCount = fridgeBasketService.countByUserId(user.getUserId());
         List<IngredientCategory> categories = ingredientCategoryService.findAll();
-        List<Ingredient> ingredients = ingredientService.findByUserId(user.getUserId());
+        List<Ingredient> ingredients = ingredientService.findByUserIdOrderByCreatedAtDesc(user.getUserId());
 
         return IngredientsResponse.from(fridgeBasketCount, categories, ingredients);
     }

--- a/src/main/java/com/recipe/app/src/ingredient/application/IngredientFacadeService.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/IngredientFacadeService.java
@@ -5,9 +5,6 @@ import com.recipe.app.src.fridgeBasket.application.FridgeBasketService;
 import com.recipe.app.src.ingredient.application.dto.IngredientsResponse;
 import com.recipe.app.src.ingredient.domain.Ingredient;
 import com.recipe.app.src.ingredient.domain.IngredientCategory;
-import com.recipe.app.src.ingredient.exception.IngredientUsedInFridgeBasketException;
-import com.recipe.app.src.ingredient.exception.IngredientUsedInFridgeException;
-import com.recipe.app.src.ingredient.exception.IngredientUsedInRecipeException;
 import com.recipe.app.src.recipe.application.RecipeIngredientService;
 import com.recipe.app.src.user.domain.User;
 import org.springframework.stereotype.Service;
@@ -55,18 +52,10 @@ public class IngredientFacadeService {
     }
 
     @Transactional(readOnly = true)
-    public void checkIngredientIsUsed(User user, Long ingredientId) {
+    public void deleteMyIngredient(User user, Long ingredientId) {
 
-        if (fridgeBasketService.hasIngredient(ingredientId)) {
-            throw new IngredientUsedInFridgeBasketException();
-        }
-
-        if (fridgeService.hasIngredient(ingredientId)) {
-            throw new IngredientUsedInFridgeException();
-        }
-
-        if (recipeIngredientService.hasIngredient(ingredientId)) {
-            throw new IngredientUsedInRecipeException();
-        }
+        fridgeService.deleteByUserIdAndIngredientId(user.getUserId(), ingredientId);
+        fridgeBasketService.deleteByUserIdAndIngredientId(user.getUserId(), ingredientId);
+        ingredientService.deleteIngredient(user, ingredientId);
     }
 }

--- a/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
@@ -107,8 +107,8 @@ public class IngredientService {
     }
 
     @Transactional(readOnly = true)
-    public List<Ingredient> findByUserId(Long userId) {
+    public List<Ingredient> findByUserIdOrderByCreatedAtDesc(Long userId) {
 
-        return ingredientRepository.findByUserId(userId);
+        return ingredientRepository.findByUserIdOrderByCreatedAtDesc(userId);
     }
 }

--- a/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
@@ -1,5 +1,6 @@
 package com.recipe.app.src.ingredient.application;
 
+import com.recipe.app.src.ingredient.application.dto.IngredientCreateResponse;
 import com.recipe.app.src.ingredient.application.dto.IngredientRequest;
 import com.recipe.app.src.ingredient.domain.Ingredient;
 import com.recipe.app.src.ingredient.domain.IngredientCategory;
@@ -54,7 +55,7 @@ public class IngredientService {
     }
 
     @Transactional
-    public void createIngredient(Long userId, IngredientRequest request) {
+    public IngredientCreateResponse createIngredient(Long userId, IngredientRequest request) {
 
         IngredientCategory ingredientCategory = ingredientCategoryService.findById(request.getIngredientCategoryId());
         Ingredient ingredient = ingredientRepository.findByUserIdAndIngredientNameAndIngredientIconIdAndIngredientCategoryId(
@@ -70,6 +71,8 @@ public class IngredientService {
                         .build());
 
         ingredientRepository.save(ingredient);
+
+        return new IngredientCreateResponse(ingredient.getIngredientId());
     }
 
     @Transactional

--- a/src/main/java/com/recipe/app/src/ingredient/application/dto/IngredientCreateResponse.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/dto/IngredientCreateResponse.java
@@ -1,0 +1,17 @@
+package com.recipe.app.src.ingredient.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(description = "재료 생성 응답 DTO")
+@Getter
+public class IngredientCreateResponse {
+
+    @Schema(description = "재료 고유 번호")
+    private final Long ingredientId;
+
+    public IngredientCreateResponse(Long ingredientId) {
+
+        this.ingredientId = ingredientId;
+    }
+}

--- a/src/main/java/com/recipe/app/src/ingredient/infra/IngredientRepository.java
+++ b/src/main/java/com/recipe/app/src/ingredient/infra/IngredientRepository.java
@@ -14,4 +14,6 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long>, I
     Optional<Ingredient> findByUserIdAndIngredientNameAndIngredientIconIdAndIngredientCategoryId(Long userId, String ingredientName, Long ingredientIconId, Long ingredientCategoryId);
 
     List<Ingredient> findByUserId(Long userId);
+
+    List<Ingredient> findByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/recipe/app/src/recipe/application/RecipeIngredientService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/RecipeIngredientService.java
@@ -114,10 +114,4 @@ public class RecipeIngredientService {
 
         return recipeIngredientRepository.findByRecipeIdIn(recipeIds);
     }
-
-    @Transactional(readOnly = true)
-    public boolean hasIngredient(Long ingredientId) {
-
-        return recipeIngredientRepository.existsByIngredientId(ingredientId);
-    }
 }

--- a/src/main/java/com/recipe/app/src/recipe/application/RecipeIngredientService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/RecipeIngredientService.java
@@ -1,33 +1,26 @@
 package com.recipe.app.src.recipe.application;
 
 import com.recipe.app.src.fridge.application.FridgeService;
-import com.recipe.app.src.ingredient.application.IngredientService;
-import com.recipe.app.src.ingredient.domain.Ingredient;
 import com.recipe.app.src.recipe.application.dto.RecipeIngredientRequest;
 import com.recipe.app.src.recipe.application.dto.RecipeIngredientResponse;
 import com.recipe.app.src.recipe.domain.RecipeIngredient;
 import com.recipe.app.src.recipe.infra.RecipeIngredientRepository;
-import com.recipe.app.src.user.domain.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
 public class RecipeIngredientService {
 
     private final RecipeIngredientRepository recipeIngredientRepository;
-    private final IngredientService ingredientService;
     private final FridgeService fridgeService;
 
 
-    public RecipeIngredientService(RecipeIngredientRepository recipeIngredientRepository, IngredientService ingredientService, FridgeService fridgeService) {
+    public RecipeIngredientService(RecipeIngredientRepository recipeIngredientRepository, FridgeService fridgeService) {
         this.recipeIngredientRepository = recipeIngredientRepository;
-        this.ingredientService = ingredientService;
         this.fridgeService = fridgeService;
     }
 
@@ -38,46 +31,13 @@ public class RecipeIngredientService {
     }
 
     @Transactional
-    public void createRecipeIngredients(User user, Long recipeId, List<RecipeIngredientRequest> request) {
+    public void createRecipeIngredients(Long recipeId, List<RecipeIngredientRequest> request) {
 
-        List<RecipeIngredient> recipeIngredients = getRecipeIngredientsWithIngredientsSave(user, recipeId, request);
-        recipeIngredients.addAll(getRecipeIngredientsByIngredientIds(recipeId, request));
+        List<RecipeIngredient> recipeIngredients = request.stream()
+                .map(recipeIngredientRequest -> recipeIngredientRequest.toEntity(recipeId))
+                .collect(Collectors.toList());
 
         recipeIngredientRepository.saveAll(recipeIngredients);
-    }
-
-    private List<RecipeIngredient> getRecipeIngredientsWithIngredientsSave(User user, Long recipeId, List<RecipeIngredientRequest> request) {
-
-        Map<Ingredient, String> capacityMapByIngredient = request.stream()
-                .filter(recipeIngredient -> recipeIngredient.getIngredientId() == null)
-                .collect(Collectors.toMap(recipeIngredient -> Ingredient.builder()
-                                .ingredientCategoryId(recipeIngredient.getIngredientCategoryId())
-                                .ingredientName(recipeIngredient.getIngredientName())
-                                .ingredientIconId(recipeIngredient.getIngredientIconId())
-                                .userId(user.getUserId())
-                                .build(),
-                        RecipeIngredientRequest::getCapacity));
-        ingredientService.createIngredients(capacityMapByIngredient.keySet());
-
-        return capacityMapByIngredient.keySet().stream()
-                .map(ingredient -> RecipeIngredient.builder()
-                        .ingredientId(ingredient.getIngredientId())
-                        .recipeId(recipeId)
-                        .capacity(capacityMapByIngredient.get(ingredient))
-                        .build())
-                .collect(Collectors.toList());
-    }
-
-    private List<RecipeIngredient> getRecipeIngredientsByIngredientIds(Long recipeId, List<RecipeIngredientRequest> request) {
-
-        return request.stream()
-                .filter(recipeIngredient -> recipeIngredient.getIngredientId() != null)
-                .map(recipeIngredient -> RecipeIngredient.builder()
-                        .ingredientId(recipeIngredient.getIngredientId())
-                        .recipeId(recipeId)
-                        .capacity(recipeIngredient.getCapacity())
-                        .build())
-                .collect(Collectors.toList());
     }
 
     @Transactional
@@ -89,18 +49,8 @@ public class RecipeIngredientService {
     @Transactional(readOnly = true)
     public List<RecipeIngredientResponse> findRecipeIngredientsByUserIdAndRecipeId(Long userId, Long recipeId) {
 
-        List<RecipeIngredient> recipeIngredients = findByRecipeId(recipeId);
-        List<Long> ingredientIds = recipeIngredients.stream()
-                .map(RecipeIngredient::getIngredientId)
-                .collect(Collectors.toList());
-        Map<Long, Ingredient> ingredientMapById = ingredientService.findByIngredientIds(ingredientIds).stream()
-                .collect(Collectors.toMap(Ingredient::getIngredientId, Function.identity()));
-
-        return recipeIngredients.stream()
-                .map(recipeIngredient -> {
-                    Ingredient ingredient = ingredientMapById.get(recipeIngredient.getIngredientId());
-                    return RecipeIngredientResponse.from(recipeIngredient, ingredient, fridgeService.isInFridge(userId, ingredient));
-                })
+        return findByRecipeId(recipeId).stream()
+                .map(recipeIngredient -> RecipeIngredientResponse.from(recipeIngredient, fridgeService.isInFridge(userId, recipeIngredient.getIngredientName())))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeIngredientRequest.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeIngredientRequest.java
@@ -1,5 +1,6 @@
 package com.recipe.app.src.recipe.application.dto;
 
+import com.recipe.app.src.recipe.domain.RecipeIngredient;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,14 +11,23 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RecipeIngredientRequest {
 
-    @Schema(description = "재료 고유 번호 (재료 선택 시 추가, 직접 재료 입력 시 null)", nullable = true)
-    private Long ingredientId;
     @Schema(description = "레시피 재료명 (직접 재료 입력 시 추가, 재료 선택 시 null)", nullable = true)
     private String ingredientName;
     @Schema(description = "레시피 재료 아이콘 고유 번호 (직접 재료 입력 시 추가, 재료 선택 시 null)", nullable = true)
     private Long ingredientIconId;
-    @Schema(description = "레시피 재료 카테고리 고유 번호 (직접 재료 입력 시 추가, 재료 선택 시 null)", nullable = true)
-    private Long ingredientCategoryId;
     @Schema(description = "레시피 재료 용량", nullable = true)
-    private String capacity;
+    private String quantity;
+    @Schema(description = "레시피 재료 단위", nullable = true)
+    private String unit;
+
+    public RecipeIngredient toEntity(Long recipeId) {
+
+        return RecipeIngredient.builder()
+                .recipeId(recipeId)
+                .ingredientName(ingredientName)
+                .ingredientIconId(ingredientIconId)
+                .quantity(quantity)
+                .unit(unit)
+                .build();
+    }
 }

--- a/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeIngredientResponse.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeIngredientResponse.java
@@ -1,6 +1,5 @@
 package com.recipe.app.src.recipe.application.dto;
 
-import com.recipe.app.src.ingredient.domain.Ingredient;
 import com.recipe.app.src.recipe.domain.RecipeIngredient;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -13,32 +12,35 @@ public class RecipeIngredientResponse {
     @Schema(description = "레시피 재료 고유 번호")
     private final Long recipeIngredientId;
     @Schema(description = "레시피 재료명")
-    private final String recipeIngredientName;
+    private final String ingredientName;
     @Schema(description = "레시피 재료 아이콘 고유 번호")
-    private final Long recipeIngredientIconId;
+    private final Long ingredientIconId;
     @Schema(description = "레시피 재료 용량")
-    private final String recipeIngredientCapacity;
+    private final String quantity;
+    @Schema(description = "레시피 재료 단위")
+    private final String unit;
     @Schema(description = "레시피 재료 냉장고 존재 여부")
     private final Boolean isInUserFridge;
 
     @Builder
-    public RecipeIngredientResponse(Long recipeIngredientId, String recipeIngredientName, Long recipeIngredientIconId,
-                                    String recipeIngredientCapacity, Boolean isInUserFridge) {
+    public RecipeIngredientResponse(Long recipeIngredientId, String ingredientName, Long ingredientIconId, String quantity, String unit, Boolean isInUserFridge) {
 
         this.recipeIngredientId = recipeIngredientId;
-        this.recipeIngredientName = recipeIngredientName;
-        this.recipeIngredientIconId = recipeIngredientIconId;
-        this.recipeIngredientCapacity = recipeIngredientCapacity;
+        this.ingredientName = ingredientName;
+        this.ingredientIconId = ingredientIconId;
+        this.quantity = quantity;
+        this.unit = unit;
         this.isInUserFridge = isInUserFridge;
     }
 
-    public static RecipeIngredientResponse from(RecipeIngredient recipeIngredient, Ingredient ingredient, boolean isInUserFridge) {
+    public static RecipeIngredientResponse from(RecipeIngredient recipeIngredient, boolean isInUserFridge) {
 
         return RecipeIngredientResponse.builder()
                 .recipeIngredientId(recipeIngredient.getRecipeIngredientId())
-                .recipeIngredientName(ingredient.getIngredientName())
-                .recipeIngredientIconId(ingredient.getIngredientIconId())
-                .recipeIngredientCapacity(recipeIngredient.getCapacity())
+                .ingredientName(recipeIngredient.getIngredientName())
+                .ingredientIconId(recipeIngredient.getIngredientIconId())
+                .quantity(recipeIngredient.getQuantity())
+                .unit(recipeIngredient.getUnit())
                 .isInUserFridge(isInUserFridge)
                 .build();
     }

--- a/src/main/java/com/recipe/app/src/recipe/domain/RecipeIngredient.java
+++ b/src/main/java/com/recipe/app/src/recipe/domain/RecipeIngredient.java
@@ -1,10 +1,12 @@
 package com.recipe.app.src.recipe.domain;
 
+import com.google.common.base.Preconditions;
 import com.recipe.app.common.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
 import java.util.Objects;
@@ -23,21 +25,29 @@ public class RecipeIngredient extends BaseEntity {
     @Column(name = "recipeId", nullable = false)
     private Long recipeId;
 
-    @Column(name = "ingredientId", nullable = false)
-    private Long ingredientId;
+    @Column(name = "ingredientName", nullable = false, length = 64)
+    private String ingredientName;
 
-    @Column(name = "capacity")
-    private String capacity;
+    @Column(name = "ingredientIconId")
+    private Long ingredientIconId;
+
+    @Column(name = "quantity")
+    private String quantity;
+
+    @Column(name = "unit")
+    private String unit;
 
     @Builder
-    public RecipeIngredient(Long recipeIngredientId, Long recipeId, Long ingredientId, String capacity) {
+    public RecipeIngredient(Long recipeIngredientId, Long recipeId, String ingredientName, Long ingredientIconId, String quantity, String unit) {
 
         Objects.requireNonNull(recipeId, "레시피 아이디를 입력해주세요.");
-        Objects.requireNonNull(ingredientId, "재료 아이디를 입력해주세요.");
+        Preconditions.checkArgument(StringUtils.hasText(ingredientName), "레시피 재료명을 입력해주세요.");
 
         this.recipeIngredientId = recipeIngredientId;
         this.recipeId = recipeId;
-        this.ingredientId = ingredientId;
-        this.capacity = capacity;
+        this.ingredientName = ingredientName;
+        this.ingredientIconId = ingredientIconId;
+        this.quantity = quantity;
+        this.unit = unit;
     }
 }

--- a/src/main/java/com/recipe/app/src/recipe/infra/RecipeCustomRepository.java
+++ b/src/main/java/com/recipe/app/src/recipe/infra/RecipeCustomRepository.java
@@ -20,5 +20,5 @@ public interface RecipeCustomRepository {
 
     List<Recipe> findLimitByUserId(Long userId, Long lastRecipeId, int size);
 
-    List<Recipe> findRecipesInFridge(Collection<Long> ingredientIds, Collection<String> ingredientNames);
+    List<Recipe> findRecipesInFridge(Collection<String> ingredientNames);
 }

--- a/src/main/java/com/recipe/app/src/recipe/infra/RecipeIngredientRepository.java
+++ b/src/main/java/com/recipe/app/src/recipe/infra/RecipeIngredientRepository.java
@@ -13,6 +13,4 @@ public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredie
     List<RecipeIngredient> findByRecipeId(Long recipeId);
 
     List<RecipeIngredient> findByRecipeIdIn(Collection<Long> recipeIds);
-
-    boolean existsByIngredientId(Long ingredientId);
 }

--- a/src/main/java/com/recipe/app/src/recipe/infra/RecipeRepositoryImpl.java
+++ b/src/main/java/com/recipe/app/src/recipe/infra/RecipeRepositoryImpl.java
@@ -9,7 +9,6 @@ import java.util.Collection;
 import java.util.List;
 
 import static com.recipe.app.common.utils.QueryUtils.ifIdIsNotNullAndGreaterThanZero;
-import static com.recipe.app.src.ingredient.domain.QIngredient.ingredient;
 import static com.recipe.app.src.recipe.domain.QRecipe.recipe;
 import static com.recipe.app.src.recipe.domain.QRecipeIngredient.recipeIngredient;
 import static com.recipe.app.src.recipe.domain.QRecipeScrap.recipeScrap;
@@ -26,13 +25,13 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
         return (long) queryFactory
                 .select(recipe.recipeId, recipe.recipeNm, recipe.introduction)
                 .from(recipe)
-                .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId))
-                .leftJoin(ingredient).on(ingredient.ingredientName.contains(keyword))
+                .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId)
+                        .and(recipeIngredient.ingredientName.contains(keyword)))
                 .where(recipe.hiddenYn.eq("N"))
                 .groupBy(recipe.recipeId)
                 .having(recipe.recipeNm.contains(keyword)
                         .or(recipe.introduction.contains(keyword))
-                        .or(ingredient.count().gt(0)))
+                        .or(recipeIngredient.count().gt(0)))
                 .fetch().size();
     }
 
@@ -41,8 +40,8 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
 
         return queryFactory
                 .selectFrom(recipe)
-                .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId))
-                .leftJoin(ingredient).on(ingredient.ingredientName.contains(keyword))
+                .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId)
+                        .and(recipeIngredient.ingredientName.contains(keyword)))
                 .where(
                         ifIdIsNotNullAndGreaterThanZero((recipeId, createdAt) -> recipe.createdAt.lt(createdAt)
                                         .or(recipe.createdAt.eq(createdAt)
@@ -53,7 +52,7 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
                 .groupBy(recipe.recipeId)
                 .having(recipe.recipeNm.contains(keyword)
                         .or(recipe.introduction.contains(keyword))
-                        .or(ingredient.count().gt(0)))
+                        .or(recipeIngredient.count().gt(0)))
                 .orderBy(recipe.createdAt.desc(), recipe.recipeId.desc())
                 .limit(size)
                 .fetch();
@@ -64,14 +63,14 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
 
         return queryFactory
                 .selectFrom(recipe)
-                .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId))
-                .leftJoin(ingredient).on(ingredient.ingredientName.contains(keyword))
+                .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId)
+                        .and(recipeIngredient.ingredientName.contains(keyword)))
                 .leftJoin(recipeScrap).on(recipeScrap.recipeId.eq(recipe.recipeId))
                 .where(recipe.hiddenYn.eq("N"))
                 .groupBy(recipe.recipeId)
                 .having(recipe.recipeNm.contains(keyword)
                                 .or(recipe.introduction.contains(keyword))
-                                .or(ingredient.count().gt(0)),
+                                .or(recipeIngredient.count().gt(0)),
                         ifIdIsNotNullAndGreaterThanZero((recipeId, recipeScrapCnt) -> recipeScrap.count().lt(recipeScrapCnt)
                                         .or(recipeScrap.count().eq(recipeScrapCnt)
                                                 .and(recipe.recipeId.lt(recipeId))),
@@ -86,14 +85,14 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
 
         return queryFactory
                 .selectFrom(recipe)
-                .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId))
-                .leftJoin(ingredient).on(ingredient.ingredientName.contains(keyword))
+                .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId)
+                        .and(recipeIngredient.ingredientName.contains(keyword)))
                 .leftJoin(recipeView).on(recipeView.recipeId.eq(recipe.recipeId))
                 .where(recipe.hiddenYn.eq("N"))
                 .groupBy(recipe.recipeId)
                 .having(recipe.recipeNm.contains(keyword)
                                 .or(recipe.introduction.contains(keyword))
-                                .or(ingredient.count().gt(0)),
+                                .or(recipeIngredient.count().gt(0)),
                         ifIdIsNotNullAndGreaterThanZero((recipeId, recipeViewCnt) -> recipeView.count().lt(recipeViewCnt)
                                         .or(recipeView.count().eq(recipeViewCnt)
                                                 .and(recipe.recipeId.lt(recipeId))),

--- a/src/main/java/com/recipe/app/src/recipe/infra/RecipeRepositoryImpl.java
+++ b/src/main/java/com/recipe/app/src/recipe/infra/RecipeRepositoryImpl.java
@@ -27,7 +27,7 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
                 .select(recipe.recipeId, recipe.recipeNm, recipe.introduction)
                 .from(recipe)
                 .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId))
-                .leftJoin(ingredient).on(ingredient.ingredientId.eq(recipeIngredient.ingredientId), ingredient.ingredientName.contains(keyword))
+                .leftJoin(ingredient).on(ingredient.ingredientName.contains(keyword))
                 .where(recipe.hiddenYn.eq("N"))
                 .groupBy(recipe.recipeId)
                 .having(recipe.recipeNm.contains(keyword)
@@ -42,7 +42,7 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
         return queryFactory
                 .selectFrom(recipe)
                 .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId))
-                .leftJoin(ingredient).on(ingredient.ingredientId.eq(recipeIngredient.ingredientId), ingredient.ingredientName.contains(keyword))
+                .leftJoin(ingredient).on(ingredient.ingredientName.contains(keyword))
                 .where(
                         ifIdIsNotNullAndGreaterThanZero((recipeId, createdAt) -> recipe.createdAt.lt(createdAt)
                                         .or(recipe.createdAt.eq(createdAt)
@@ -65,7 +65,7 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
         return queryFactory
                 .selectFrom(recipe)
                 .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId))
-                .leftJoin(ingredient).on(ingredient.ingredientId.eq(recipeIngredient.ingredientId), ingredient.ingredientName.contains(keyword))
+                .leftJoin(ingredient).on(ingredient.ingredientName.contains(keyword))
                 .leftJoin(recipeScrap).on(recipeScrap.recipeId.eq(recipe.recipeId))
                 .where(recipe.hiddenYn.eq("N"))
                 .groupBy(recipe.recipeId)
@@ -87,7 +87,7 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
         return queryFactory
                 .selectFrom(recipe)
                 .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId))
-                .leftJoin(ingredient).on(ingredient.ingredientId.eq(recipeIngredient.ingredientId), ingredient.ingredientName.contains(keyword))
+                .leftJoin(ingredient).on(ingredient.ingredientName.contains(keyword))
                 .leftJoin(recipeView).on(recipeView.recipeId.eq(recipe.recipeId))
                 .where(recipe.hiddenYn.eq("N"))
                 .groupBy(recipe.recipeId)
@@ -135,15 +135,13 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
     }
 
     @Override
-    public List<Recipe> findRecipesInFridge(Collection<Long> ingredientIds, Collection<String> ingredientNames) {
+    public List<Recipe> findRecipesInFridge(Collection<String> ingredientNames) {
 
         return queryFactory
                 .selectFrom(recipe)
                 .join(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId))
-                .join(ingredient).on(ingredient.ingredientId.eq(recipeIngredient.ingredientId))
                 .where(
-                        ingredient.ingredientId.in(ingredientIds)
-                                .or(ingredient.ingredientName.in(ingredientNames)),
+                        (recipeIngredient.ingredientName.in(ingredientNames)),
                         recipe.hiddenYn.eq("N")
                 )
                 .groupBy(recipe.recipeId)

--- a/src/test/groovy/com/recipe/app/src/recipe/infra/RecipeCustomRepositoryTest.groovy
+++ b/src/test/groovy/com/recipe/app/src/recipe/infra/RecipeCustomRepositoryTest.groovy
@@ -1,9 +1,5 @@
 package com.recipe.app.src.recipe.infra
 
-import com.recipe.app.src.ingredient.domain.Ingredient
-import com.recipe.app.src.ingredient.domain.IngredientCategory
-import com.recipe.app.src.ingredient.infra.IngredientCategoryRepository
-import com.recipe.app.src.ingredient.infra.IngredientRepository
 import com.recipe.app.src.recipe.domain.Recipe
 import com.recipe.app.src.recipe.domain.RecipeIngredient
 import com.recipe.app.src.recipe.domain.RecipeLevel
@@ -27,10 +23,6 @@ class RecipeCustomRepositoryTest extends Specification {
     @Autowired
     UserRepository userRepository;
     @Autowired
-    IngredientCategoryRepository ingredientCategoryRepository;
-    @Autowired
-    IngredientRepository ingredientRepository;
-    @Autowired
     RecipeIngredientRepository recipeIngredientRepository;
     @Autowired
     RecipeRepository recipeRepository;
@@ -40,7 +32,6 @@ class RecipeCustomRepositoryTest extends Specification {
     RecipeViewRepository recipeViewRepository;
 
     private List<User> users;
-    private List<Ingredient> ingredients;
 
     void setup() {
         users = [
@@ -54,30 +45,6 @@ class RecipeCustomRepositoryTest extends Specification {
                         .build(),
         ]
         userRepository.saveAll(users);
-
-        IngredientCategory ingredientCategory = IngredientCategory.builder()
-                .ingredientCategoryName("카테고리")
-                .build();
-        ingredientCategoryRepository.save(ingredientCategory);
-
-        ingredients = [
-                Ingredient.builder()
-                        .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
-                        .ingredientName("테스트")
-                        .userId(users.get(0).userId)
-                        .build(),
-                Ingredient.builder()
-                        .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
-                        .ingredientName("재료1")
-                        .userId(users.get(0).userId)
-                        .build(),
-                Ingredient.builder()
-                        .ingredientCategoryId(ingredientCategory.ingredientCategoryId)
-                        .ingredientName("재료2")
-                        .userId(users.get(0).userId)
-                        .build(),
-        ]
-        ingredientRepository.saveAll(ingredients);
     }
 
     def "검색어로 레시피 갯수 조회"() {
@@ -110,16 +77,16 @@ class RecipeCustomRepositoryTest extends Specification {
 
         List<RecipeIngredient> recipeIngredients = [
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(0).recipeId)
+                        .ingredientName("재료")
                         .build(),
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(1).recipeId)
+                        .ingredientName("재료")
                         .build(),
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(2).recipeId)
+                        .ingredientName("테스트")
                         .build(),
         ]
         recipeIngredientRepository.saveAll(recipeIngredients);
@@ -161,16 +128,16 @@ class RecipeCustomRepositoryTest extends Specification {
 
         List<RecipeIngredient> recipeIngredients = [
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(0).recipeId)
+                        .ingredientName("재료")
                         .build(),
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(1).recipeId)
+                        .ingredientName("재료")
                         .build(),
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(2).recipeId)
+                        .ingredientName("테스트")
                         .build(),
         ]
         recipeIngredientRepository.saveAll(recipeIngredients);
@@ -216,16 +183,16 @@ class RecipeCustomRepositoryTest extends Specification {
 
         List<RecipeIngredient> recipeIngredients = [
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(0).recipeId)
+                        .ingredientName("재료")
                         .build(),
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(1).recipeId)
+                        .ingredientName("재료")
                         .build(),
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(2).recipeId)
+                        .ingredientName("테스트")
                         .build(),
         ]
         recipeIngredientRepository.saveAll(recipeIngredients);
@@ -289,16 +256,16 @@ class RecipeCustomRepositoryTest extends Specification {
 
         List<RecipeIngredient> recipeIngredients = [
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(0).recipeId)
+                .ingredientName("재료")
                         .build(),
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(1).recipeId)
+                        .ingredientName("재료")
                         .build(),
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(2).recipeId)
+                        .ingredientName("테스트")
                         .build(),
         ]
         recipeIngredientRepository.saveAll(recipeIngredients);
@@ -448,34 +415,22 @@ class RecipeCustomRepositoryTest extends Specification {
 
         List<RecipeIngredient> recipeIngredients = [
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(0).recipeId)
+                        .ingredientName("테스트")
                         .build(),
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(1).ingredientId)
-                        .recipeId(recipes.get(0).recipeId)
-                        .build(),
-                RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(2).ingredientId)
-                        .recipeId(recipes.get(0).recipeId)
-                        .build(),
-                RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(2).ingredientId)
                         .recipeId(recipes.get(1).recipeId)
+                        .ingredientName("재료")
                         .build(),
                 RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(0).ingredientId)
                         .recipeId(recipes.get(2).recipeId)
-                        .build(),
-                RecipeIngredient.builder()
-                        .ingredientId(ingredients.get(2).ingredientId)
-                        .recipeId(recipes.get(2).recipeId)
+                        .ingredientName("테스트")
                         .build(),
         ]
         recipeIngredientRepository.saveAll(recipeIngredients);
 
         when:
-        List<Recipe> response = recipeRepository.findRecipesInFridge([ingredients.get(1).ingredientId], ["테스트"]);
+        List<Recipe> response = recipeRepository.findRecipesInFridge(["테스트"]);
 
         then:
         response.size() == 2


### PR DESCRIPTION
## Issue Number

-

## Summary

- 나만의 재료 목록 조회 시 등록 최신순으로 조회되도록 수정
- 나만의 재료 삭제 시 냉장고, 냉장고바구니 항목 함께 제거되도록 수정
- 나만의 재료 추가 시 아이디값 응답으로 전달하도록 수정
- 레시피 재료와 냉장고 재료 도메인 분리

## Describe

- 나만의 재료 목록 조회 시 등록 최신순으로 조회되도록 수정
  - 그냥 아이디순으로 조회되던 부분에서 변경
- 나만의 재료 삭제 시 냉장고, 냉장고바구니 항목 함께 제거되도록 수정
  - 재료 삭제 시 사용하는 곳 있으면 삭제 막아뒀었는데, 삭제 알림창과 함께 다 같이 제거되도록 하기로 함
- 나만의 재료 추가 시 아이디값 응답으로 전달하도록 수정
  - 클라이언트측 요청에 따라 응답값 변경
- 레시피 재료와 냉장고 재료 도메인 분리
  - 재료 자체는 삭제될 때 냉장고, 바구니와 함께 제거되는데 레시피에서 해당 재료 사용하고 있으면 레시피 지우는 건 좀 그럴 것 같음. 그래서 레시피 재료는 따로 분리하도록 DB 테이블 변경.

## ETC

-