### PR TITLE
Feature/fix recipes bugs

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -33,15 +33,15 @@ then
 fi
 
 # docker 구동
-DOCKER_PID=$(pgrep -f $PROJECT_ROOT/deploy/docker-compose.yml)
+DOCKER_PID=$(pgrep -f $PROJECT_ROOT/docker-compose.yml)
 if [ -z $CURRENT_PID ]; then
   echo "start docker-compose up"
-  sudo docker-compose -f $PROJECT_ROOT/deploy/docker-compose.yml up --build -d
+  sudo docker-compose -f $PROJECT_ROOT/docker-compose.yml up --build -d
 fi
 
 # build 파일 복사
 echo "$TIME_NOW > $WAR_FILE 파일 복사" >> $DEPLOY_LOG
-cp $PROJECT_ROOT/deploy/*.war $WAR_FILE
+cp $PROJECT_ROOT/*.war $WAR_FILE
 cp $PROJECT_ROOT/keystore.p12 /keystore.p12
 
 # 실행권한 추가

--- a/src/main/java/com/recipe/app/src/recipe/api/BlogRecipeController.java
+++ b/src/main/java/com/recipe/app/src/recipe/api/BlogRecipeController.java
@@ -36,7 +36,7 @@ public class BlogRecipeController {
                                                         @ApiParam(name = "size", type = "int", example = "20", value = "사이즈")
                                                         @RequestParam(value = "size") int size,
                                                         @ApiParam(name = "sort", type = "String", example = "조회수순(blogViews) / 좋아요순(blogScraps) / 최신순(newest) = 기본값", value = "정렬")
-                                                        @RequestParam(value = "sort") String sort) throws IOException, ParseException {
+                                                        @RequestParam(value = "sort") String sort) {
 
         if (authentication == null)
             throw new UserTokenNotExistException();

--- a/src/main/java/com/recipe/app/src/recipe/api/YoutubeRecipeController.java
+++ b/src/main/java/com/recipe/app/src/recipe/api/YoutubeRecipeController.java
@@ -35,7 +35,7 @@ public class YoutubeRecipeController {
                                                            @ApiParam(name = "size", type = "int", example = "20", value = "사이즈")
                                                            @RequestParam(value = "size") int size,
                                                            @ApiParam(name = "sort", type = "String", example = "조회수순(youtubeViews) / 좋아요순(youtubeScraps) / 최신순(newest) = 기본값", value = "정렬")
-                                                           @RequestParam(value = "sort") String sort) throws IOException {
+                                                           @RequestParam(value = "sort") String sort) {
 
         if (authentication == null)
             throw new UserTokenNotExistException();

--- a/src/main/java/com/recipe/app/src/recipe/application/RecipeViewService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/RecipeViewService.java
@@ -6,7 +6,6 @@ import com.recipe.app.src.user.domain.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
 import java.util.List;
 
 @Service
@@ -40,12 +39,6 @@ public class RecipeViewService {
     public List<RecipeView> findByRecipeId(Long recipeId) {
 
         return recipeViewRepository.findByRecipeId(recipeId);
-    }
-
-    @Transactional(readOnly = true)
-    public List<RecipeView> findByRecipeIds(Collection<Long> recipeIds) {
-
-        return recipeViewRepository.findByRecipeIdIn(recipeIds);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/recipe/app/src/recipe/application/blog/BlogRecipeService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/blog/BlogRecipeService.java
@@ -6,7 +6,6 @@ import com.recipe.app.src.recipe.application.dto.RecipeResponse;
 import com.recipe.app.src.recipe.application.dto.RecipesResponse;
 import com.recipe.app.src.recipe.domain.blog.BlogRecipe;
 import com.recipe.app.src.recipe.domain.blog.BlogScrap;
-import com.recipe.app.src.recipe.domain.blog.BlogView;
 import com.recipe.app.src.recipe.exception.NotFoundRecipeException;
 import com.recipe.app.src.recipe.infra.blog.BlogRecipeRepository;
 import com.recipe.app.src.user.domain.User;
@@ -18,7 +17,6 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -110,15 +108,11 @@ public class BlogRecipeService {
                 .map(BlogRecipe::getBlogRecipeId)
                 .collect(Collectors.toList());
         List<BlogScrap> blogScraps = blogScrapService.findByBlogRecipeIds(blogRecipeIds);
-        List<BlogView> blogViews = blogViewService.findByBlogRecipeIds(blogRecipeIds);
 
         return new RecipesResponse(totalCnt, blogRecipes.stream()
                 .map(blogRecipe -> {
-                    long scrapCnt = getBlogScrapCnt(blogScraps, blogRecipe.getBlogRecipeId(), user);
-                    long viewCnt = getBlogViewCnt(blogViews, blogRecipe.getBlogRecipeId(), user);
-                    boolean isUserScrap = isUserScrap(blogScraps, blogRecipe.getBlogRecipeId(), user);
 
-                    return RecipeResponse.from(blogRecipe, isUserScrap, scrapCnt, viewCnt);
+                    return RecipeResponse.from(blogRecipe, isUserScrap(blogScraps, blogRecipe.getBlogRecipeId(), user));
                 })
                 .collect(Collectors.toList()));
     }
@@ -126,18 +120,6 @@ public class BlogRecipeService {
     private boolean isUserScrap(List<BlogScrap> blogScraps, Long blogRecipeId, User user) {
         return blogScraps.stream()
                 .anyMatch(blogScrap -> blogScrap.getBlogRecipeId().equals(blogRecipeId) && blogScrap.getUserId().equals(user.getUserId()));
-    }
-
-    private long getBlogViewCnt(List<BlogView> blogViews, Long blogRecipeId, User user) {
-        return blogViews.stream()
-                .filter(blogView -> blogView.getBlogViewId().equals(blogRecipeId) && blogView.getUserId().equals(user.getUserId()))
-                .count();
-    }
-
-    private long getBlogScrapCnt(List<BlogScrap> blogScraps, Long blogRecipeId, User user) {
-        return blogScraps.stream()
-                .filter(blogScrap -> blogScrap.getBlogRecipeId().equals(blogRecipeId) && blogScrap.getUserId().equals(user.getUserId()))
-                .count();
     }
 
     @Transactional

--- a/src/main/java/com/recipe/app/src/recipe/application/blog/BlogRecipeService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/blog/BlogRecipeService.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -53,18 +54,16 @@ public class BlogRecipeService {
     private String naverClientSecret;
 
     @Transactional
-    public RecipesResponse getBlogRecipes(User user, String keyword, Long lastBlogRecipeId, int size, String sort) throws IOException, ParseException {
+    public RecipesResponse getBlogRecipes(User user, String keyword, Long lastBlogRecipeId, int size, String sort) {
 
         badWordService.checkBadWords(keyword);
 
         long totalCnt = blogRecipeRepository.countByKeyword(keyword);
+        List<BlogRecipe> blogRecipes = findByKeywordSortBy(keyword, lastBlogRecipeId, size, sort);
 
         if (totalCnt < 10) {
-            searchNaverBlogRecipes(keyword);
-            totalCnt = blogRecipeRepository.countByKeyword(keyword);
+            searchNaverBlogRecipes(keyword).join();
         }
-
-        List<BlogRecipe> blogRecipes = findByKeywordSortBy(keyword, lastBlogRecipeId, size, sort);
 
         return getRecipes(user, totalCnt, blogRecipes);
     }
@@ -119,48 +118,52 @@ public class BlogRecipeService {
                 .anyMatch(blogScrap -> blogScrap.getBlogRecipeId().equals(blogRecipeId) && blogScrap.getUserId().equals(user.getUserId()));
     }
 
-    @Transactional
-    public void searchNaverBlogRecipes(String keyword) throws IOException, ParseException {
+    private CompletableFuture<Void> searchNaverBlogRecipes(String keyword) {
 
-        String apiURL = "https://openapi.naver.com/v1/search/blog?sort=sim&start=1&display=100&query=" + URLEncoder.encode(keyword + " 레시피", "UTF-8");
+        return CompletableFuture.runAsync(() -> {
+            try {
+                String apiURL = "https://openapi.naver.com/v1/search/blog?sort=sim&start=1&display=50&query=" + URLEncoder.encode(keyword + " 레시피", "UTF-8");
 
-        Map<String, String> requestHeaders = new HashMap<>();
-        requestHeaders.put("X-Naver-Client-Id", naverClientId);
-        requestHeaders.put("X-Naver-Client-Secret", naverClientSecret);
+                Map<String, String> requestHeaders = new HashMap<>();
+                requestHeaders.put("X-Naver-Client-Id", naverClientId);
+                requestHeaders.put("X-Naver-Client-Secret", naverClientSecret);
 
-        JSONObject response = HttpUtil.getHTTP(apiURL, requestHeaders);
-        JSONArray items = (JSONArray) response.get("items");
-        int total = Integer.parseInt(response.get("total").toString());
+                JSONObject response = HttpUtil.getHTTP(apiURL, requestHeaders);
+                JSONArray items = (JSONArray) response.get("items");
 
-        List<BlogRecipe> blogs = new ArrayList<>();
-        for (Object item : items) {
-            String title = ((JSONObject) item).get("title").toString()
-                    .replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", "");
-            String blogUrl = ((JSONObject) item).get("link").toString();
-            String description = ((JSONObject) item).get("description").toString()
-                    .replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", "");
-            String blogName = ((JSONObject) item).get("bloggername").toString();
-            LocalDate publishedAt = LocalDate.parse(((JSONObject) item).get("postdate").toString(), DateTimeFormatter.ofPattern("yyyyMMdd"));
-            String thumbnail = getBlogThumbnailUrl(blogUrl);
+                List<BlogRecipe> blogs = new ArrayList<>();
+                for (Object item : items) {
+                    String title = ((JSONObject) item).get("title").toString()
+                            .replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", "");
+                    String blogUrl = ((JSONObject) item).get("link").toString();
+                    String description = ((JSONObject) item).get("description").toString()
+                            .replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", "");
+                    String blogName = ((JSONObject) item).get("bloggername").toString();
+                    LocalDate publishedAt = LocalDate.parse(((JSONObject) item).get("postdate").toString(), DateTimeFormatter.ofPattern("yyyyMMdd"));
+                    String thumbnail = getBlogThumbnailUrl(blogUrl);
 
-            blogs.add(BlogRecipe.builder()
-                    .blogUrl(blogUrl)
-                    .blogThumbnailImgUrl(thumbnail)
-                    .title(title)
-                    .description(description)
-                    .publishedAt(publishedAt)
-                    .blogName(blogName)
-                    .build());
-        }
+                    blogs.add(BlogRecipe.builder()
+                            .blogUrl(blogUrl)
+                            .blogThumbnailImgUrl(thumbnail)
+                            .title(title)
+                            .description(description)
+                            .publishedAt(publishedAt)
+                            .blogName(blogName)
+                            .build());
+                }
 
-        List<String> blogUrls = blogs.stream().map(BlogRecipe::getBlogUrl).collect(Collectors.toList());
-        List<BlogRecipe> existBlogRecipes = blogRecipeRepository.findByBlogUrlIn(blogUrls);
-        Map<String, BlogRecipe> existBlogRecipeMapByBlogUrl = existBlogRecipes.stream().collect(Collectors.toMap(BlogRecipe::getBlogUrl, Function.identity()));
-        List<BlogRecipe> blogRecipes = blogs.stream()
-                .map(blog -> existBlogRecipeMapByBlogUrl.getOrDefault(blog.getBlogUrl(), blog))
-                .collect(Collectors.toList());
+                List<String> blogUrls = blogs.stream().map(BlogRecipe::getBlogUrl).collect(Collectors.toList());
+                List<BlogRecipe> existBlogRecipes = blogRecipeRepository.findByBlogUrlIn(blogUrls);
+                Map<String, BlogRecipe> existBlogRecipeMapByBlogUrl = existBlogRecipes.stream().collect(Collectors.toMap(BlogRecipe::getBlogUrl, Function.identity()));
+                List<BlogRecipe> blogRecipes = blogs.stream()
+                        .map(blog -> existBlogRecipeMapByBlogUrl.getOrDefault(blog.getBlogUrl(), blog))
+                        .collect(Collectors.toList());
 
-        blogRecipeRepository.saveAll(blogRecipes);
+                blogRecipeRepository.saveAll(blogRecipes);
+            } catch (IOException | ParseException e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     private String getBlogThumbnailUrl(String blogUrl) {

--- a/src/main/java/com/recipe/app/src/recipe/application/blog/BlogRecipeService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/blog/BlogRecipeService.java
@@ -54,7 +54,7 @@ public class BlogRecipeService {
     @Value("${naver.client-secret}")
     private String naverClientSecret;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public RecipesResponse getBlogRecipes(User user, String keyword, Long lastBlogRecipeId, int size, String sort) throws IOException, ParseException {
 
         badWordService.checkBadWords(keyword);

--- a/src/main/java/com/recipe/app/src/recipe/application/blog/BlogRecipeService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/blog/BlogRecipeService.java
@@ -110,10 +110,7 @@ public class BlogRecipeService {
         List<BlogScrap> blogScraps = blogScrapService.findByBlogRecipeIds(blogRecipeIds);
 
         return new RecipesResponse(totalCnt, blogRecipes.stream()
-                .map(blogRecipe -> {
-
-                    return RecipeResponse.from(blogRecipe, isUserScrap(blogScraps, blogRecipe.getBlogRecipeId(), user));
-                })
+                .map(blogRecipe -> RecipeResponse.from(blogRecipe, isUserScrap(blogScraps, blogRecipe.getBlogRecipeId(), user)))
                 .collect(Collectors.toList()));
     }
 

--- a/src/main/java/com/recipe/app/src/recipe/application/blog/BlogViewService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/blog/BlogViewService.java
@@ -1,13 +1,11 @@
 package com.recipe.app.src.recipe.application.blog;
 
-import com.recipe.app.src.recipe.domain.blog.BlogRecipe;
 import com.recipe.app.src.recipe.domain.blog.BlogView;
 import com.recipe.app.src.recipe.infra.blog.BlogViewRepository;
 import com.recipe.app.src.user.domain.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
 import java.util.List;
 
 @Service
@@ -36,12 +34,6 @@ public class BlogViewService {
 
         List<BlogView> blogViews = blogViewRepository.findByUserId(user.getUserId());
         blogViewRepository.deleteAll(blogViews);
-    }
-
-    @Transactional(readOnly = true)
-    public List<BlogView> findByBlogRecipeIds(Collection<Long> blogRecipeIds) {
-
-        return blogViewRepository.findByBlogRecipeIdIn(blogRecipeIds);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeResponse.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeResponse.java
@@ -66,7 +66,7 @@ public class RecipeResponse {
                 .build();
     }
 
-    public static RecipeResponse from(BlogRecipe recipe, boolean isScrapByUser, long scrapCnt, long viewCnt) {
+    public static RecipeResponse from(BlogRecipe recipe, boolean isScrapByUser) {
         return RecipeResponse.builder()
                 .recipeId(recipe.getBlogRecipeId())
                 .recipeName(recipe.getTitle())
@@ -76,8 +76,8 @@ public class RecipeResponse {
                 .postDate(recipe.getPublishedAt().format(DateTimeFormatter.ofPattern("yyyy.M.d")))
                 .linkUrl(recipe.getBlogUrl())
                 .isUserScrap(isScrapByUser)
-                .scrapCnt(scrapCnt)
-                .viewCnt(viewCnt)
+                .scrapCnt(recipe.getScrapCnt())
+                .viewCnt(recipe.getViewCnt())
                 .build();
     }
 

--- a/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeResponse.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeResponse.java
@@ -51,7 +51,7 @@ public class RecipeResponse {
         this.viewCnt = viewCnt;
     }
 
-    public static RecipeResponse from(Recipe recipe, User recipePostUser, boolean isScrapByUser, long scrapCnt, long viewCnt) {
+    public static RecipeResponse from(Recipe recipe, User recipePostUser, boolean isScrapByUser) {
 
         return RecipeResponse.builder()
                 .recipeId(recipe.getRecipeId())
@@ -61,8 +61,8 @@ public class RecipeResponse {
                 .postUserName(recipePostUser != null ? recipePostUser.getNickname() : null)
                 .postDate(recipe.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.M.d")))
                 .isUserScrap(isScrapByUser)
-                .scrapCnt(scrapCnt)
-                .viewCnt(viewCnt)
+                .scrapCnt(recipe.getScrapCnt())
+                .viewCnt(recipe.getViewCnt())
                 .build();
     }
 

--- a/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeResponse.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/dto/RecipeResponse.java
@@ -81,7 +81,7 @@ public class RecipeResponse {
                 .build();
     }
 
-    public static RecipeResponse from(YoutubeRecipe recipe, boolean isScrapByUser, long scrapCnt, long viewCnt) {
+    public static RecipeResponse from(YoutubeRecipe recipe, boolean isScrapByUser) {
         return RecipeResponse.builder()
                 .recipeId(recipe.getYoutubeRecipeId())
                 .recipeName(recipe.getTitle())
@@ -91,8 +91,8 @@ public class RecipeResponse {
                 .postDate(recipe.getPostDate().format(DateTimeFormatter.ofPattern("yyyy.M.d")))
                 .linkUrl("https://www.youtube.com/watch?v=" + recipe.getYoutubeId())
                 .isUserScrap(isScrapByUser)
-                .scrapCnt(scrapCnt)
-                .viewCnt(viewCnt)
+                .scrapCnt(recipe.getScrapCnt())
+                .viewCnt(recipe.getViewCnt())
                 .build();
     }
 }

--- a/src/main/java/com/recipe/app/src/recipe/application/dto/RecommendedRecipeResponse.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/dto/RecommendedRecipeResponse.java
@@ -52,7 +52,7 @@ public class RecommendedRecipeResponse {
         this.ingredientsMatchRate = ingredientsMatchRate;
     }
 
-    public static RecommendedRecipeResponse from(Recipe recipe, User recipePostUser, int ingredientsMatchRate, boolean isScrapByUser, long scrapCnt, long viewCnt) {
+    public static RecommendedRecipeResponse from(Recipe recipe, User recipePostUser, int ingredientsMatchRate, boolean isScrapByUser) {
 
         return RecommendedRecipeResponse.builder()
                 .recipeId(recipe.getRecipeId())
@@ -62,8 +62,8 @@ public class RecommendedRecipeResponse {
                 .postUserName(recipePostUser != null ? recipePostUser.getNickname() : null)
                 .postDate(recipe.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.M.d")))
                 .isUserScrap(isScrapByUser)
-                .scrapCnt(scrapCnt)
-                .viewCnt(viewCnt)
+                .scrapCnt(recipe.getScrapCnt())
+                .viewCnt(recipe.getViewCnt())
                 .ingredientsMatchRate(ingredientsMatchRate)
                 .build();
     }

--- a/src/main/java/com/recipe/app/src/recipe/application/youtube/YoutubeRecipeService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/youtube/YoutubeRecipeService.java
@@ -59,7 +59,7 @@ public class YoutubeRecipeService {
     @Value("${google.api-key}")
     private String youtubeApiKey;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public RecipesResponse getYoutubeRecipes(User user, String keyword, Long lastYoutubeRecipeId, int size, String sort) throws IOException {
 
         badWordService.checkBadWords(keyword);

--- a/src/main/java/com/recipe/app/src/recipe/application/youtube/YoutubeViewService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/youtube/YoutubeViewService.java
@@ -38,12 +38,6 @@ public class YoutubeViewService {
     }
 
     @Transactional(readOnly = true)
-    public List<YoutubeView> findByYoutubeRecipeIds(Collection<Long> youtubeRecipeIds) {
-
-        return youtubeViewRepository.findByYoutubeRecipeIdIn(youtubeRecipeIds);
-    }
-
-    @Transactional(readOnly = true)
     public long countByYoutubeRecipeId(Long youtubeRecipeId) {
 
         return youtubeViewRepository.countByYoutubeRecipeId(youtubeRecipeId);

--- a/src/main/java/com/recipe/app/src/recipe/domain/Recipe.java
+++ b/src/main/java/com/recipe/app/src/recipe/domain/Recipe.java
@@ -57,7 +57,7 @@ public class Recipe extends BaseEntity {
 
     @Builder
     public Recipe(Long recipeId, String recipeNm, String introduction, Long cookingTime, RecipeLevel level,
-                  String imgUrl, Long quantity, Long calorie, Long userId, boolean isHidden) {
+                  String imgUrl, Long quantity, Long calorie, Long userId, boolean isHidden, long scrapCnt, long viewCnt) {
 
         Preconditions.checkArgument(StringUtils.hasText(recipeNm), "레시피명을 입력해주세요.");
         Objects.requireNonNull(userId, "유저 아이디를 입력해주세요.");
@@ -72,6 +72,8 @@ public class Recipe extends BaseEntity {
         this.calorie = calorie;
         this.userId = userId;
         this.hiddenYn = isHidden ? "Y" : "N";
+        this.scrapCnt = scrapCnt;
+        this.viewCnt = viewCnt;
     }
 
     public void updateRecipe(String recipeNm, String imgUrl) {

--- a/src/main/java/com/recipe/app/src/recipe/domain/Recipe.java
+++ b/src/main/java/com/recipe/app/src/recipe/domain/Recipe.java
@@ -50,10 +50,10 @@ public class Recipe extends BaseEntity {
     private String hiddenYn = "Y";
 
     @Column(name = "scrapCnt", nullable = false)
-    private int scrapCnt;
+    private long scrapCnt;
 
     @Column(name = "viewCnt", nullable = false)
-    private int viewCnt;
+    private long viewCnt;
 
     @Builder
     public Recipe(Long recipeId, String recipeNm, String introduction, Long cookingTime, RecipeLevel level,

--- a/src/main/java/com/recipe/app/src/recipe/domain/blog/BlogRecipe.java
+++ b/src/main/java/com/recipe/app/src/recipe/domain/blog/BlogRecipe.java
@@ -48,7 +48,7 @@ public class BlogRecipe extends BaseEntity {
     private long viewCnt;
 
     @Builder
-    public BlogRecipe(Long blogRecipeId, String blogUrl, String blogThumbnailImgUrl, String title, String description, LocalDate publishedAt, String blogName) {
+    public BlogRecipe(Long blogRecipeId, String blogUrl, String blogThumbnailImgUrl, String title, String description, LocalDate publishedAt, String blogName, long scrapCnt, long viewCnt) {
 
         Preconditions.checkArgument(StringUtils.hasText(blogUrl), "블로그 URL을 입력해주세요.");
         Preconditions.checkArgument(StringUtils.hasText(title), "블로그 레시피 제목을 입력해주세요.");
@@ -63,6 +63,8 @@ public class BlogRecipe extends BaseEntity {
         this.description = description;
         this.publishedAt = publishedAt;
         this.blogName = blogName;
+        this.scrapCnt = scrapCnt;
+        this.viewCnt = viewCnt;
     }
 
     public void plusScrapCnt() {

--- a/src/main/java/com/recipe/app/src/recipe/domain/blog/BlogRecipe.java
+++ b/src/main/java/com/recipe/app/src/recipe/domain/blog/BlogRecipe.java
@@ -42,10 +42,10 @@ public class BlogRecipe extends BaseEntity {
     private String blogName;
 
     @Column(name = "scrapCnt", nullable = false)
-    private int scrapCnt;
+    private long scrapCnt;
 
     @Column(name = "viewCnt", nullable = false)
-    private int viewCnt;
+    private long viewCnt;
 
     @Builder
     public BlogRecipe(Long blogRecipeId, String blogUrl, String blogThumbnailImgUrl, String title, String description, LocalDate publishedAt, String blogName) {

--- a/src/main/java/com/recipe/app/src/recipe/domain/youtube/YoutubeRecipe.java
+++ b/src/main/java/com/recipe/app/src/recipe/domain/youtube/YoutubeRecipe.java
@@ -48,7 +48,7 @@ public class YoutubeRecipe extends BaseEntity {
     private long viewCnt;
 
     @Builder
-    public YoutubeRecipe(Long youtubeRecipeId, String title, String description, String thumbnailImgUrl, LocalDate postDate, String channelName, String youtubeId) {
+    public YoutubeRecipe(Long youtubeRecipeId, String title, String description, String thumbnailImgUrl, LocalDate postDate, String channelName, String youtubeId, long scrapCnt, long viewCnt) {
 
         Preconditions.checkArgument(StringUtils.hasText(title), "유튜브 레시피 제목을 입력해주세요.");
         Preconditions.checkArgument(StringUtils.hasText(thumbnailImgUrl), "유튜브 레시피 썸네일 URL을 입력해주세요.");
@@ -63,6 +63,8 @@ public class YoutubeRecipe extends BaseEntity {
         this.postDate = postDate;
         this.channelName = channelName;
         this.youtubeId = youtubeId;
+        this.scrapCnt = scrapCnt;
+        this.viewCnt = viewCnt;
     }
 
     public void plusScrapCnt() {

--- a/src/main/java/com/recipe/app/src/recipe/domain/youtube/YoutubeRecipe.java
+++ b/src/main/java/com/recipe/app/src/recipe/domain/youtube/YoutubeRecipe.java
@@ -42,10 +42,10 @@ public class YoutubeRecipe extends BaseEntity {
     private String youtubeId;
 
     @Column(name = "scrapCnt", nullable = false)
-    private int scrapCnt;
+    private long scrapCnt;
 
     @Column(name = "viewCnt", nullable = false)
-    private int viewCnt;
+    private long viewCnt;
 
     @Builder
     public YoutubeRecipe(Long youtubeRecipeId, String title, String description, String thumbnailImgUrl, LocalDate postDate, String channelName, String youtubeId) {

--- a/src/main/java/com/recipe/app/src/recipe/infra/RecipeRepositoryImpl.java
+++ b/src/main/java/com/recipe/app/src/recipe/infra/RecipeRepositoryImpl.java
@@ -12,7 +12,6 @@ import static com.recipe.app.common.utils.QueryUtils.ifIdIsNotNullAndGreaterThan
 import static com.recipe.app.src.recipe.domain.QRecipe.recipe;
 import static com.recipe.app.src.recipe.domain.QRecipeIngredient.recipeIngredient;
 import static com.recipe.app.src.recipe.domain.QRecipeScrap.recipeScrap;
-import static com.recipe.app.src.recipe.domain.QRecipeView.recipeView;
 
 public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCustomRepository {
 
@@ -65,17 +64,16 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
                 .selectFrom(recipe)
                 .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId)
                         .and(recipeIngredient.ingredientName.contains(keyword)))
-                .leftJoin(recipeScrap).on(recipeScrap.recipeId.eq(recipe.recipeId))
-                .where(recipe.hiddenYn.eq("N"))
-                .groupBy(recipe.recipeId)
-                .having(recipe.recipeNm.contains(keyword)
-                                .or(recipe.introduction.contains(keyword))
-                                .or(recipeIngredient.count().gt(0)),
-                        ifIdIsNotNullAndGreaterThanZero((recipeId, recipeScrapCnt) -> recipeScrap.count().lt(recipeScrapCnt)
-                                        .or(recipeScrap.count().eq(recipeScrapCnt)
+                .where(recipe.hiddenYn.eq("N"),
+                        ifIdIsNotNullAndGreaterThanZero((recipeId, recipeScrapCnt) -> recipe.scrapCnt.lt(recipeScrapCnt)
+                                        .or(recipe.scrapCnt.eq(recipeScrapCnt)
                                                 .and(recipe.recipeId.lt(recipeId))),
                                 lastRecipeId, lastRecipeScrapCnt))
-                .orderBy(recipeScrap.count().desc(), recipe.recipeId.desc())
+                .groupBy(recipe.recipeId)
+                .having(recipe.recipeNm.contains(keyword)
+                        .or(recipe.introduction.contains(keyword))
+                        .or(recipeIngredient.count().gt(0)))
+                .orderBy(recipe.scrapCnt.desc(), recipe.recipeId.desc())
                 .limit(size)
                 .fetch();
     }
@@ -87,17 +85,16 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
                 .selectFrom(recipe)
                 .leftJoin(recipeIngredient).on(recipe.recipeId.eq(recipeIngredient.recipeId)
                         .and(recipeIngredient.ingredientName.contains(keyword)))
-                .leftJoin(recipeView).on(recipeView.recipeId.eq(recipe.recipeId))
-                .where(recipe.hiddenYn.eq("N"))
-                .groupBy(recipe.recipeId)
-                .having(recipe.recipeNm.contains(keyword)
-                                .or(recipe.introduction.contains(keyword))
-                                .or(recipeIngredient.count().gt(0)),
-                        ifIdIsNotNullAndGreaterThanZero((recipeId, recipeViewCnt) -> recipeView.count().lt(recipeViewCnt)
-                                        .or(recipeView.count().eq(recipeViewCnt)
+                .where(recipe.hiddenYn.eq("N"),
+                        ifIdIsNotNullAndGreaterThanZero((recipeId, recipeViewCnt) -> recipe.viewCnt.lt(recipeViewCnt)
+                                        .or(recipe.viewCnt.eq(recipeViewCnt)
                                                 .and(recipe.recipeId.lt(recipeId))),
                                 lastRecipeId, lastRecipeViewCnt))
-                .orderBy(recipeView.count().desc(), recipe.recipeId.desc())
+                .groupBy(recipe.recipeId)
+                .having(recipe.recipeNm.contains(keyword)
+                        .or(recipe.introduction.contains(keyword))
+                        .or(recipeIngredient.count().gt(0)))
+                .orderBy(recipe.viewCnt.desc(), recipe.recipeId.desc())
                 .limit(size)
                 .fetch();
     }

--- a/src/main/java/com/recipe/app/src/recipe/infra/blog/BlogRecipeRepositoryImpl.java
+++ b/src/main/java/com/recipe/app/src/recipe/infra/blog/BlogRecipeRepositoryImpl.java
@@ -11,7 +11,6 @@ import java.util.List;
 import static com.recipe.app.common.utils.QueryUtils.*;
 import static com.recipe.app.src.recipe.domain.blog.QBlogRecipe.blogRecipe;
 import static com.recipe.app.src.recipe.domain.blog.QBlogScrap.blogScrap;
-import static com.recipe.app.src.recipe.domain.blog.QBlogView.blogView;
 
 public class BlogRecipeRepositoryImpl extends BaseRepositoryImpl implements BlogRecipeCustomRepository {
 

--- a/src/main/java/com/recipe/app/src/recipe/infra/blog/BlogRecipeRepositoryImpl.java
+++ b/src/main/java/com/recipe/app/src/recipe/infra/blog/BlogRecipeRepositoryImpl.java
@@ -55,17 +55,15 @@ public class BlogRecipeRepositoryImpl extends BaseRepositoryImpl implements Blog
 
         return queryFactory
                 .selectFrom(blogRecipe)
-                .leftJoin(blogScrap).on(blogRecipe.blogRecipeId.eq(blogScrap.blogRecipeId))
                 .where(
                         blogRecipe.title.contains(keyword)
-                                .or(blogRecipe.description.contains(keyword))
+                                .or(blogRecipe.description.contains(keyword)),
+                        ifIdIsNotNullAndGreaterThanZero((blogRecipeId, blogScrapCnt) -> blogRecipe.scrapCnt.lt(blogScrapCnt)
+                                        .or(blogRecipe.scrapCnt.eq(blogScrapCnt)
+                                                .and(blogRecipe.blogRecipeId.lt(blogRecipeId))),
+                                lastBlogRecipeId, lastBlogScrapCnt)
                 )
-                .groupBy(blogRecipe.blogRecipeId)
-                .having(ifIdIsNotNullAndGreaterThanZero((blogRecipeId, blogScrapCnt) -> blogScrap.count().lt(blogScrapCnt)
-                                .or(blogScrap.count().eq(blogScrapCnt)
-                                        .and(blogRecipe.blogRecipeId.lt(blogRecipeId))),
-                        lastBlogRecipeId, lastBlogScrapCnt))
-                .orderBy(blogScrap.count().desc(), blogRecipe.blogRecipeId.desc())
+                .orderBy(blogRecipe.scrapCnt.desc(), blogRecipe.blogRecipeId.desc())
                 .limit(size)
                 .fetch();
     }
@@ -75,17 +73,15 @@ public class BlogRecipeRepositoryImpl extends BaseRepositoryImpl implements Blog
 
         return queryFactory
                 .selectFrom(blogRecipe)
-                .leftJoin(blogView).on(blogRecipe.blogRecipeId.eq(blogView.blogRecipeId))
                 .where(
                         blogRecipe.title.contains(keyword)
-                                .or(blogRecipe.description.contains(keyword))
+                                .or(blogRecipe.description.contains(keyword)),
+                        ifIdIsNotNullAndGreaterThanZero((blogRecipeId, blogViewCnt) -> blogRecipe.viewCnt.lt(blogViewCnt)
+                                        .or(blogRecipe.viewCnt.eq(blogViewCnt)
+                                                .and(blogRecipe.blogRecipeId.lt(blogRecipeId))),
+                                lastBlogRecipeId, lastBlogViewCnt)
                 )
-                .groupBy(blogRecipe.blogRecipeId)
-                .having(ifIdIsNotNullAndGreaterThanZero((blogRecipeId, blogViewCnt) -> blogView.count().lt(blogViewCnt)
-                                .or(blogView.count().eq(blogViewCnt)
-                                        .and(blogRecipe.blogRecipeId.lt(blogRecipeId))),
-                        lastBlogRecipeId, lastBlogViewCnt))
-                .orderBy(blogView.count().desc(), blogRecipe.blogRecipeId.desc())
+                .orderBy(blogRecipe.viewCnt.desc(), blogRecipe.blogRecipeId.desc())
                 .limit(size)
                 .fetch();
     }

--- a/src/main/java/com/recipe/app/src/recipe/infra/youtube/YoutubeRecipeRepositoryImpl.java
+++ b/src/main/java/com/recipe/app/src/recipe/infra/youtube/YoutubeRecipeRepositoryImpl.java
@@ -11,7 +11,6 @@ import java.util.List;
 import static com.recipe.app.common.utils.QueryUtils.ifIdIsNotNullAndGreaterThanZero;
 import static com.recipe.app.src.recipe.domain.youtube.QYoutubeRecipe.youtubeRecipe;
 import static com.recipe.app.src.recipe.domain.youtube.QYoutubeScrap.youtubeScrap;
-import static com.recipe.app.src.recipe.domain.youtube.QYoutubeView.youtubeView;
 
 public class YoutubeRecipeRepositoryImpl extends BaseRepositoryImpl implements YoutubeRecipeCustomRepository {
 
@@ -55,17 +54,15 @@ public class YoutubeRecipeRepositoryImpl extends BaseRepositoryImpl implements Y
 
         return queryFactory
                 .selectFrom(youtubeRecipe)
-                .leftJoin(youtubeScrap).on(youtubeScrap.youtubeRecipeId.eq(youtubeRecipe.youtubeRecipeId))
                 .where(
                         youtubeRecipe.title.contains(keyword)
-                                .or(youtubeRecipe.description.contains(keyword))
+                                .or(youtubeRecipe.description.contains(keyword)),
+                        ifIdIsNotNullAndGreaterThanZero((youtubeRecipeId, youtubeScrapCnt) -> youtubeRecipe.scrapCnt.lt(youtubeScrapCnt)
+                                        .or(youtubeRecipe.scrapCnt.eq(youtubeScrapCnt)
+                                                .and(youtubeRecipe.youtubeRecipeId.lt(youtubeRecipeId))),
+                                lastYoutubeRecipeId, lastYoutubeScrapCnt)
                 )
-                .groupBy(youtubeRecipe.youtubeRecipeId)
-                .having(ifIdIsNotNullAndGreaterThanZero((youtubeRecipeId, youtubeScrapCnt) -> youtubeScrap.count().lt(youtubeScrapCnt)
-                                .or(youtubeScrap.count().eq(youtubeScrapCnt)
-                                        .and(youtubeRecipe.youtubeRecipeId.lt(youtubeRecipeId))),
-                        lastYoutubeRecipeId, lastYoutubeScrapCnt))
-                .orderBy(youtubeScrap.count().desc(), youtubeRecipe.youtubeRecipeId.desc())
+                .orderBy(youtubeRecipe.scrapCnt.desc(), youtubeRecipe.youtubeRecipeId.desc())
                 .limit(size)
                 .fetch();
     }
@@ -75,17 +72,15 @@ public class YoutubeRecipeRepositoryImpl extends BaseRepositoryImpl implements Y
 
         return queryFactory
                 .selectFrom(youtubeRecipe)
-                .leftJoin(youtubeView).on(youtubeView.youtubeRecipeId.eq(youtubeRecipe.youtubeRecipeId))
                 .where(
                         youtubeRecipe.title.contains(keyword)
-                                .or(youtubeRecipe.description.contains(keyword))
+                                .or(youtubeRecipe.description.contains(keyword)),
+                        ifIdIsNotNullAndGreaterThanZero((youtubeRecipeId, youtubeViewCnt) -> youtubeRecipe.viewCnt.lt(youtubeViewCnt)
+                                        .or(youtubeRecipe.viewCnt.eq(youtubeViewCnt)
+                                                .and(youtubeRecipe.youtubeRecipeId.lt(youtubeRecipeId))),
+                                lastYoutubeRecipeId, lastYoutubeViewCnt)
                 )
-                .groupBy(youtubeRecipe.youtubeRecipeId)
-                .having(ifIdIsNotNullAndGreaterThanZero((youtubeRecipeId, youtubeViewCnt) -> youtubeView.count().lt(youtubeViewCnt)
-                                .or(youtubeView.count().eq(youtubeViewCnt)
-                                        .and(youtubeRecipe.youtubeRecipeId.lt(youtubeRecipeId))),
-                        lastYoutubeRecipeId, lastYoutubeViewCnt))
-                .orderBy(youtubeView.count().desc(), youtubeRecipe.youtubeRecipeId.desc())
+                .orderBy(youtubeRecipe.viewCnt.desc(), youtubeRecipe.youtubeRecipeId.desc())
                 .limit(size)
                 .fetch();
     }

--- a/src/test/groovy/com/recipe/app/src/recipe/infra/RecipeCustomRepositoryTest.groovy
+++ b/src/test/groovy/com/recipe/app/src/recipe/infra/RecipeCustomRepositoryTest.groovy
@@ -28,8 +28,6 @@ class RecipeCustomRepositoryTest extends Specification {
     RecipeRepository recipeRepository;
     @Autowired
     RecipeScrapRepository recipeScrapRepository;
-    @Autowired
-    RecipeViewRepository recipeViewRepository;
 
     private List<User> users;
 
@@ -163,6 +161,7 @@ class RecipeCustomRepositoryTest extends Specification {
                         .level(RecipeLevel.NORMAL)
                         .userId(users.get(0).userId)
                         .isHidden(false)
+                        .scrapCnt(2L)
                         .build(),
                 Recipe.builder()
                         .recipeNm("제목")
@@ -170,6 +169,7 @@ class RecipeCustomRepositoryTest extends Specification {
                         .level(RecipeLevel.NORMAL)
                         .userId(users.get(0).userId)
                         .isHidden(false)
+                        .scrapCnt(0L)
                         .build(),
                 Recipe.builder()
                         .recipeNm("제목")
@@ -177,6 +177,7 @@ class RecipeCustomRepositoryTest extends Specification {
                         .level(RecipeLevel.NORMAL)
                         .userId(users.get(0).userId)
                         .isHidden(false)
+                        .scrapCnt(2L)
                         .build(),
         ]
         recipeRepository.saveAll(recipes);
@@ -196,26 +197,6 @@ class RecipeCustomRepositoryTest extends Specification {
                         .build(),
         ]
         recipeIngredientRepository.saveAll(recipeIngredients);
-
-        List<RecipeScrap> recipeScraps = [
-                RecipeScrap.builder()
-                        .userId(users.get(0).userId)
-                        .recipeId(recipes.get(0).recipeId)
-                        .build(),
-                RecipeScrap.builder()
-                        .userId(users.get(1).userId)
-                        .recipeId(recipes.get(0).recipeId)
-                        .build(),
-                RecipeScrap.builder()
-                        .userId(users.get(0).userId)
-                        .recipeId(recipes.get(2).recipeId)
-                        .build(),
-                RecipeScrap.builder()
-                        .userId(users.get(1).userId)
-                        .recipeId(recipes.get(2).recipeId)
-                        .build(),
-        ]
-        recipeScrapRepository.saveAll(recipeScraps);
 
         when:
         List<Recipe> response = recipeRepository.findByKeywordLimitOrderByRecipeScrapCntDesc("테스트", recipes.get(2).recipeId, 2, 3);
@@ -236,6 +217,7 @@ class RecipeCustomRepositoryTest extends Specification {
                         .level(RecipeLevel.NORMAL)
                         .userId(users.get(0).userId)
                         .isHidden(false)
+                        .viewCnt(2L)
                         .build(),
                 Recipe.builder()
                         .recipeNm("제목")
@@ -243,6 +225,7 @@ class RecipeCustomRepositoryTest extends Specification {
                         .level(RecipeLevel.NORMAL)
                         .userId(users.get(0).userId)
                         .isHidden(false)
+                        .viewCnt(0L)
                         .build(),
                 Recipe.builder()
                         .recipeNm("제목")
@@ -250,6 +233,7 @@ class RecipeCustomRepositoryTest extends Specification {
                         .level(RecipeLevel.NORMAL)
                         .userId(users.get(0).userId)
                         .isHidden(false)
+                        .viewCnt(2L)
                         .build(),
         ]
         recipeRepository.saveAll(recipes);
@@ -257,7 +241,7 @@ class RecipeCustomRepositoryTest extends Specification {
         List<RecipeIngredient> recipeIngredients = [
                 RecipeIngredient.builder()
                         .recipeId(recipes.get(0).recipeId)
-                .ingredientName("재료")
+                        .ingredientName("재료")
                         .build(),
                 RecipeIngredient.builder()
                         .recipeId(recipes.get(1).recipeId)
@@ -269,26 +253,6 @@ class RecipeCustomRepositoryTest extends Specification {
                         .build(),
         ]
         recipeIngredientRepository.saveAll(recipeIngredients);
-
-        List<RecipeView> recipeViews = [
-                RecipeView.builder()
-                        .userId(users.get(0).userId)
-                        .recipeId(recipes.get(0).recipeId)
-                        .build(),
-                RecipeView.builder()
-                        .userId(users.get(1).userId)
-                        .recipeId(recipes.get(0).recipeId)
-                        .build(),
-                RecipeView.builder()
-                        .userId(users.get(0).userId)
-                        .recipeId(recipes.get(2).recipeId)
-                        .build(),
-                RecipeView.builder()
-                        .userId(users.get(0).userId)
-                        .recipeId(recipes.get(2).recipeId)
-                        .build(),
-        ]
-        recipeViewRepository.saveAll(recipeViews);
 
         when:
         List<Recipe> response = recipeRepository.findByKeywordLimitOrderByRecipeViewCntDesc("테스트", recipes.get(2).recipeId, 2, 3);

--- a/src/test/groovy/com/recipe/app/src/recipe/infra/blog/BlogRecipeCustomRepositoryTest.groovy
+++ b/src/test/groovy/com/recipe/app/src/recipe/infra/blog/BlogRecipeCustomRepositoryTest.groovy
@@ -25,8 +25,6 @@ class BlogRecipeCustomRepositoryTest extends Specification {
     @Autowired
     BlogScrapRepository blogScrapRepository;
     @Autowired
-    BlogViewRepository blogViewRepository;
-    @Autowired
     BlogRecipeRepository blogRecipeRepository;
 
     def "검색어로 블로그 레시피 갯수 조회"() {
@@ -143,6 +141,7 @@ class BlogRecipeCustomRepositoryTest extends Specification {
                         .blogUrl("http://naver.com")
                         .blogThumbnailImgUrl("http://test.jpg")
                         .blogName("테스트")
+                        .scrapCnt(0L)
                         .build(),
                 BlogRecipe.builder()
                         .title("제목2")
@@ -151,6 +150,7 @@ class BlogRecipeCustomRepositoryTest extends Specification {
                         .blogUrl("http://naver.com")
                         .blogThumbnailImgUrl("http://test.jpg")
                         .blogName("테스트")
+                        .scrapCnt(2L)
                         .build(),
                 BlogRecipe.builder()
                         .title("제목3")
@@ -159,6 +159,7 @@ class BlogRecipeCustomRepositoryTest extends Specification {
                         .blogUrl("http://naver.com")
                         .blogThumbnailImgUrl("http://test.jpg")
                         .blogName("테스트")
+                        .scrapCnt(1L)
                         .build(),
                 BlogRecipe.builder()
                         .title("테스트제목3")
@@ -167,37 +168,10 @@ class BlogRecipeCustomRepositoryTest extends Specification {
                         .blogUrl("http://naver.com")
                         .blogThumbnailImgUrl("http://test.jpg")
                         .blogName("테스트")
+                        .scrapCnt(3L)
                         .build()
         ]
         blogRecipeRepository.saveAll(blogRecipes);
-
-        List<BlogScrap> blogScraps = [
-                BlogScrap.builder()
-                        .userId(users.get(0).userId)
-                        .blogRecipeId(blogRecipes.get(3).blogRecipeId)
-                        .build(),
-                BlogScrap.builder()
-                        .userId(users.get(1).userId)
-                        .blogRecipeId(blogRecipes.get(3).blogRecipeId)
-                        .build(),
-                BlogScrap.builder()
-                        .userId(users.get(2).userId)
-                        .blogRecipeId(blogRecipes.get(3).blogRecipeId)
-                        .build(),
-                BlogScrap.builder()
-                        .userId(users.get(0).userId)
-                        .blogRecipeId(blogRecipes.get(2).blogRecipeId)
-                        .build(),
-                BlogScrap.builder()
-                        .userId(users.get(0).userId)
-                        .blogRecipeId(blogRecipes.get(1).blogRecipeId)
-                        .build(),
-                BlogScrap.builder()
-                        .userId(users.get(1).userId)
-                        .blogRecipeId(blogRecipes.get(1).blogRecipeId)
-                        .build()
-        ]
-        blogScrapRepository.saveAll(blogScraps);
 
         when:
         List<BlogRecipe> response = blogRecipeRepository.findByKeywordLimitOrderByBlogScrapCntDesc("테스트", blogRecipes.get(3).blogRecipeId, 3, 3);
@@ -231,6 +205,7 @@ class BlogRecipeCustomRepositoryTest extends Specification {
                         .blogUrl("http://naver.com")
                         .blogThumbnailImgUrl("http://test.jpg")
                         .blogName("테스트")
+                        .viewCnt(2L)
                         .build(),
                 BlogRecipe.builder()
                         .title("제목2")
@@ -239,6 +214,7 @@ class BlogRecipeCustomRepositoryTest extends Specification {
                         .blogUrl("http://naver.com")
                         .blogThumbnailImgUrl("http://test.jpg")
                         .blogName("테스트")
+                        .viewCnt(0L)
                         .build(),
                 BlogRecipe.builder()
                         .title("제목3")
@@ -247,6 +223,7 @@ class BlogRecipeCustomRepositoryTest extends Specification {
                         .blogUrl("http://naver.com")
                         .blogThumbnailImgUrl("http://test.jpg")
                         .blogName("테스트")
+                        .viewCnt(0L)
                         .build(),
                 BlogRecipe.builder()
                         .title("테스트제목3")
@@ -255,29 +232,10 @@ class BlogRecipeCustomRepositoryTest extends Specification {
                         .blogUrl("http://naver.com")
                         .blogThumbnailImgUrl("http://test.jpg")
                         .blogName("테스트")
+                        .viewCnt(2L)
                         .build()
         ]
         blogRecipeRepository.saveAll(blogRecipes);
-
-        List<BlogView> blogViews = [
-                BlogView.builder()
-                        .userId(users.get(0).userId)
-                        .blogRecipeId(blogRecipes.get(3).blogRecipeId)
-                        .build(),
-                BlogView.builder()
-                        .userId(users.get(1).userId)
-                        .blogRecipeId(blogRecipes.get(3).blogRecipeId)
-                        .build(),
-                BlogView.builder()
-                        .userId(users.get(0).userId)
-                        .blogRecipeId(blogRecipes.get(0).blogRecipeId)
-                        .build(),
-                BlogView.builder()
-                        .userId(users.get(1).userId)
-                        .blogRecipeId(blogRecipes.get(0).blogRecipeId)
-                        .build(),
-        ]
-        blogViewRepository.saveAll(blogViews);
 
         when:
         List<BlogRecipe> response = blogRecipeRepository.findByKeywordLimitOrderByBlogViewCntDesc("테스트", blogRecipes.get(3).blogRecipeId, 2, 3);
@@ -346,7 +304,7 @@ class BlogRecipeCustomRepositoryTest extends Specification {
         blogScrapRepository.saveAll(blogScraps);
 
         when:
-        List<BlogRecipe> response = blogRecipeRepository.findUserScrapBlogRecipesLimit(user.userId, 0L, blogScraps.get(0).createdAt.plusHours(1),3)
+        List<BlogRecipe> response = blogRecipeRepository.findUserScrapBlogRecipesLimit(user.userId, 0L, blogScraps.get(0).createdAt.plusHours(1), 3)
 
         then:
         response.size() == 2

--- a/src/test/groovy/com/recipe/app/src/recipe/infra/youtube/YoutubeRecipeCustomRepositoryTest.groovy
+++ b/src/test/groovy/com/recipe/app/src/recipe/infra/youtube/YoutubeRecipeCustomRepositoryTest.groovy
@@ -26,8 +26,6 @@ class YoutubeRecipeCustomRepositoryTest extends Specification {
     YoutubeRecipeRepository youtubeRecipeRepository;
     @Autowired
     YoutubeScrapRepository youtubeScrapRepository;
-    @Autowired
-    YoutubeViewRepository youtubeViewRepository;
 
     def "검색어로 유튜브 레시피 갯수 조회"() {
 
@@ -147,6 +145,7 @@ class YoutubeRecipeCustomRepositoryTest extends Specification {
                         .channelName("테스트")
                         .youtubeId("youtube1")
                         .thumbnailImgUrl("http://test.jpg")
+                        .scrapCnt(0L)
                         .build(),
                 YoutubeRecipe.builder()
                         .title("테스트제목")
@@ -155,6 +154,7 @@ class YoutubeRecipeCustomRepositoryTest extends Specification {
                         .channelName("테스트")
                         .youtubeId("youtube2")
                         .thumbnailImgUrl("http://test.jpg")
+                        .scrapCnt(2L)
                         .build(),
                 YoutubeRecipe.builder()
                         .title("제목")
@@ -163,6 +163,7 @@ class YoutubeRecipeCustomRepositoryTest extends Specification {
                         .channelName("테스트")
                         .youtubeId("youtube3")
                         .thumbnailImgUrl("http://test.jpg")
+                        .scrapCnt(1L)
                         .build(),
                 YoutubeRecipe.builder()
                         .title("제목")
@@ -171,33 +172,10 @@ class YoutubeRecipeCustomRepositoryTest extends Specification {
                         .channelName("테스트")
                         .youtubeId("youtube4")
                         .thumbnailImgUrl("http://test.jpg")
+                        .scrapCnt(2L)
                         .build(),
         ]
         youtubeRecipeRepository.saveAll(youtubeRecipes);
-
-        List<YoutubeScrap> youtubeScraps = [
-                YoutubeScrap.builder()
-                        .userId(users.get(0).userId)
-                        .youtubeRecipeId(youtubeRecipes.get(3).youtubeRecipeId)
-                        .build(),
-                YoutubeScrap.builder()
-                        .userId(users.get(1).userId)
-                        .youtubeRecipeId(youtubeRecipes.get(3).youtubeRecipeId)
-                        .build(),
-                YoutubeScrap.builder()
-                        .userId(users.get(0).userId)
-                        .youtubeRecipeId(youtubeRecipes.get(2).youtubeRecipeId)
-                        .build(),
-                YoutubeScrap.builder()
-                        .userId(users.get(0).userId)
-                        .youtubeRecipeId(youtubeRecipes.get(1).youtubeRecipeId)
-                        .build(),
-                YoutubeScrap.builder()
-                        .userId(users.get(1).userId)
-                        .youtubeRecipeId(youtubeRecipes.get(1).youtubeRecipeId)
-                        .build(),
-        ]
-        youtubeScrapRepository.saveAll(youtubeScraps);
 
         when:
         List<YoutubeRecipe> response = youtubeRecipeRepository.findByKeywordLimitOrderByYoutubeScrapCntDesc("테스트", youtubeRecipes.get(3).youtubeRecipeId, 2, 3);
@@ -231,6 +209,7 @@ class YoutubeRecipeCustomRepositoryTest extends Specification {
                         .channelName("테스트")
                         .youtubeId("youtube1")
                         .thumbnailImgUrl("http://test.jpg")
+                        .viewCnt(0L)
                         .build(),
                 YoutubeRecipe.builder()
                         .title("테스트제목")
@@ -239,6 +218,7 @@ class YoutubeRecipeCustomRepositoryTest extends Specification {
                         .channelName("테스트")
                         .youtubeId("youtube2")
                         .thumbnailImgUrl("http://test.jpg")
+                        .viewCnt(2L)
                         .build(),
                 YoutubeRecipe.builder()
                         .title("제목")
@@ -247,6 +227,7 @@ class YoutubeRecipeCustomRepositoryTest extends Specification {
                         .channelName("테스트")
                         .youtubeId("youtube3")
                         .thumbnailImgUrl("http://test.jpg")
+                        .viewCnt(1L)
                         .build(),
                 YoutubeRecipe.builder()
                         .title("제목")
@@ -255,33 +236,10 @@ class YoutubeRecipeCustomRepositoryTest extends Specification {
                         .channelName("테스트")
                         .youtubeId("youtube4")
                         .thumbnailImgUrl("http://test.jpg")
+                        .viewCnt(2L)
                         .build(),
         ]
         youtubeRecipeRepository.saveAll(youtubeRecipes);
-
-        List<YoutubeView> youtubeViews = [
-                YoutubeView.builder()
-                        .userId(users.get(0).userId)
-                        .youtubeRecipeId(youtubeRecipes.get(3).youtubeRecipeId)
-                        .build(),
-                YoutubeView.builder()
-                        .userId(users.get(1).userId)
-                        .youtubeRecipeId(youtubeRecipes.get(3).youtubeRecipeId)
-                        .build(),
-                YoutubeView.builder()
-                        .userId(users.get(0).userId)
-                        .youtubeRecipeId(youtubeRecipes.get(2).youtubeRecipeId)
-                        .build(),
-                YoutubeView.builder()
-                        .userId(users.get(0).userId)
-                        .youtubeRecipeId(youtubeRecipes.get(1).youtubeRecipeId)
-                        .build(),
-                YoutubeView.builder()
-                        .userId(users.get(0).userId)
-                        .youtubeRecipeId(youtubeRecipes.get(1).youtubeRecipeId)
-                        .build(),
-        ]
-        youtubeViewRepository.saveAll(youtubeViews);
 
         when:
         List<YoutubeRecipe> response = youtubeRecipeRepository.findByKeywordLimitOrderByYoutubeViewCntDesc("테스트", youtubeRecipes.get(3).youtubeRecipeId, 2, 3)


### PR DESCRIPTION
## Issue Number

-

## Summary

- 블로그, 유튜브 재검색 시 트랜잭션 오류 수정
- 블로그/유튜브/추천 레시피 조회 시 스크랩수와 조회수 정렬 오류 수정
- 블로그/유튜브 api 호출 시 비동기 처리

## Describe

- 블로그, 유튜브 검색 시 결과값이 10개 이하인 경우 API 요청 새로 주고 있는데 읽기 트랜잭션 처리로 인해 새로 검색 후 저장할 때 오류 발생
  - 트랜잭션을 쓰기 트랜잭션으로 수정
- 블로그/유튜브/추천 레시피 스크랩수와 조회수를 DB 비정규화한 항목으로 변경 (조인을 줄이도록함)
- 블로그/유튜브 레시피 양 부족한 경우 외부 api 호출 후 저장할 때 조회와 별개로 작업 이루어지도록 비동기 처리

## ETC

- github actions 시작 스크립스 폴더 위치 설정 변경
