### PR TITLE
Feature/fix jwt with refresh token

### DIFF
--- a/src/main/java/com/recipe/app/config/GeneralExceptionHandler.java
+++ b/src/main/java/com/recipe/app/config/GeneralExceptionHandler.java
@@ -7,8 +7,6 @@ import com.recipe.app.src.ingredient.exception.NotFoundIngredientCategoryExcepti
 import com.recipe.app.src.ingredient.exception.NotFoundIngredientException;
 import com.recipe.app.src.recipe.exception.NotFoundRecipeException;
 import com.recipe.app.src.recipe.exception.NotFoundRecipeLevelException;
-import com.recipe.app.src.user.exception.ForbiddenAccessException;
-import com.recipe.app.src.user.exception.ForbiddenUserException;
 import com.recipe.app.src.user.exception.NotFoundUserException;
 import com.recipe.app.src.user.exception.UserTokenNotExistException;
 import org.slf4j.Logger;
@@ -29,12 +27,6 @@ public class GeneralExceptionHandler {
     public ResponseEntity<?> handleNotFoundException(Exception e) {
         log.error(e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e);
-    }
-
-    @ExceptionHandler({ForbiddenAccessException.class, ForbiddenUserException.class})
-    public ResponseEntity<?> handleForbiddenException(Exception e) {
-        log.error(e.getMessage());
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e);
     }
 
     @ExceptionHandler({UserTokenNotExistException.class})

--- a/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
@@ -7,7 +7,6 @@ import com.recipe.app.src.ingredient.domain.IngredientCategory;
 import com.recipe.app.src.ingredient.exception.NotFoundIngredientException;
 import com.recipe.app.src.ingredient.infra.IngredientRepository;
 import com.recipe.app.src.user.domain.User;
-import com.recipe.app.src.user.exception.ForbiddenUserException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;

--- a/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
+++ b/src/main/java/com/recipe/app/src/ingredient/application/IngredientService.java
@@ -98,13 +98,9 @@ public class IngredientService {
     @Transactional
     public void deleteIngredient(User user, Long ingredientId) {
 
-        Ingredient ingredient = ingredientRepository.findById(ingredientId).orElseThrow(() -> {
+        Ingredient ingredient = ingredientRepository.findByIngredientIdAndUserId(ingredientId, user.getUserId()).orElseThrow(() -> {
             throw new NotFoundIngredientException();
         });
-
-        if (!user.getUserId().equals(ingredient.getUserId())) {
-            throw new ForbiddenUserException();
-        }
 
         ingredientRepository.delete(ingredient);
     }

--- a/src/main/java/com/recipe/app/src/ingredient/infra/IngredientRepository.java
+++ b/src/main/java/com/recipe/app/src/ingredient/infra/IngredientRepository.java
@@ -14,4 +14,6 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long>, I
     Optional<Ingredient> findByUserIdAndIngredientNameAndIngredientIconIdAndIngredientCategoryId(Long userId, String ingredientName, Long ingredientIconId, Long ingredientCategoryId);
 
     List<Ingredient> findByUserId(Long userId);
+
+    Optional<Ingredient> findByIngredientIdAndUserId(Long ingredientId, Long userId);
 }

--- a/src/main/java/com/recipe/app/src/recipe/application/RecipeService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/RecipeService.java
@@ -21,7 +21,6 @@ import com.recipe.app.src.recipe.infra.RecipeRepository;
 import com.recipe.app.src.user.application.UserService;
 import com.recipe.app.src.user.application.dto.UserRecipeResponse;
 import com.recipe.app.src.user.domain.User;
-import com.recipe.app.src.user.exception.ForbiddenUserException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;

--- a/src/main/java/com/recipe/app/src/recipe/application/RecipeService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/RecipeService.java
@@ -90,12 +90,10 @@ public class RecipeService {
     @Transactional(readOnly = true)
     public RecipeDetailResponse getRecipe(User user, Long recipeId) {
 
-        Recipe recipe = recipeRepository.findById(recipeId)
+        Recipe recipe = recipeRepository.findRecipeDetail(recipeId, user.getUserId())
                 .orElseThrow(() -> {
                     throw new NotFoundRecipeException();
                 });
-        if (recipe.isHidden() && !user.getUserId().equals(recipe.getUserId()))
-            throw new ForbiddenUserException();
 
         List<RecipeIngredientResponse> recipeIngredients = recipeIngredientService.findRecipeIngredientsByUserIdAndRecipeId(user.getUserId(), recipeId);
         List<RecipeProcessResponse> recipeProcesses = recipeProcessService.fineRecipeProcessesByRecipeId(recipeId);

--- a/src/main/java/com/recipe/app/src/recipe/infra/RecipeCustomRepository.java
+++ b/src/main/java/com/recipe/app/src/recipe/infra/RecipeCustomRepository.java
@@ -5,8 +5,11 @@ import com.recipe.app.src.recipe.domain.Recipe;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface RecipeCustomRepository {
+
+    Optional<Recipe> findRecipeDetail(Long recipeId, Long userId);
 
     Long countByKeyword(String keyword);
 

--- a/src/main/java/com/recipe/app/src/recipe/infra/RecipeRepositoryImpl.java
+++ b/src/main/java/com/recipe/app/src/recipe/infra/RecipeRepositoryImpl.java
@@ -7,6 +7,7 @@ import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import static com.recipe.app.common.utils.QueryUtils.ifIdIsNotNullAndGreaterThanZero;
 import static com.recipe.app.src.recipe.domain.QRecipe.recipe;
@@ -17,6 +18,17 @@ public class RecipeRepositoryImpl extends BaseRepositoryImpl implements RecipeCu
 
     public RecipeRepositoryImpl(EntityManager em) {
         super(em);
+    }
+
+    @Override
+    public Optional<Recipe> findRecipeDetail(Long recipeId, Long userId) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(recipe)
+                .where(recipe.recipeId.eq(recipeId)
+                        .and(recipe.hiddenYn.eq("N")
+                                .or(recipe.hiddenYn.eq("Y").and(recipe.userId.eq(userId))))
+                        )
+                .fetchOne());
     }
 
     @Override

--- a/src/main/java/com/recipe/app/src/user/application/UserService.java
+++ b/src/main/java/com/recipe/app/src/user/application/UserService.java
@@ -267,6 +267,7 @@ public class UserService {
         return UserTokenRefreshResponse.builder()
                 .userId(request.getUserId())
                 .accessToken(jwtUtil.createAccessToken(request.getUserId()))
+                .refreshToken(jwtUtil.createRefreshToken(request.getUserId()))
                 .build();
     }
 }

--- a/src/main/java/com/recipe/app/src/user/application/dto/UserTokenRefreshResponse.java
+++ b/src/main/java/com/recipe/app/src/user/application/dto/UserTokenRefreshResponse.java
@@ -13,4 +13,6 @@ public class UserTokenRefreshResponse {
     private Long userId;
     @Schema(description = "액세스 토큰")
     private String accessToken;
+    @Schema(description = "리프레시 토큰")
+    private String refreshToken;
 }

--- a/src/main/java/com/recipe/app/src/user/exception/ForbiddenUserException.java
+++ b/src/main/java/com/recipe/app/src/user/exception/ForbiddenUserException.java
@@ -1,8 +1,0 @@
-package com.recipe.app.src.user.exception;
-
-public class ForbiddenUserException extends RuntimeException {
-
-    public ForbiddenUserException() {
-        super("해당 정보에 접근할 수 없는 회원입니다.");
-    }
-}


### PR DESCRIPTION
## Issue Number

#89 

## Summary

- 토큰 재발급 요청 시 리프레시 토큰도 같이 발급
- 토큰 만료 외 403 예외 처리 다르게 하도록 수정

## Describe

- 리프레시 토큰 만료로 인한 재로그인 요청 줄이기 위함
- 401, 403 상태일 때 토큰 재발급 요청 처리하기로 함
  - 이에 따라 기존에 자원에 대한 권한이 없던 커스텀 예외 처리 중 403 인 부분 수정
  - 예외 핸들러에서 403 처리 하던 커스텀 예외 부분 제거
  - 권한이 없는 자원 요청 시 조건 파라미터로 요청하고 없으면 404 예외로 처리되도록 수정

## ETC

-
