### PR TITLE
refactor: 레시피 조회 시 정렬값을 views, scraps, newest로 통일하도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,9 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
-    implementation 'org.jsoup:jsoup:1.13.1'
+    implementation 'org.jsoup:jsoup:1.18.1'
 
-    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '5.0.0-alpha.14'
 
     implementation group: 'com.google.api-client', name: 'google-api-client', version: '1.25.0'
     implementation group: 'com.google.apis', name: 'google-api-services-youtube', version: 'v3-rev212-1.25.0'
@@ -64,7 +64,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.0'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.1.3'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 

--- a/src/main/java/com/recipe/app/src/recipe/api/BlogRecipeController.java
+++ b/src/main/java/com/recipe/app/src/recipe/api/BlogRecipeController.java
@@ -36,7 +36,7 @@ public class BlogRecipeController {
                                           @RequestParam(value = "startAfter") long startAfter,
                                           @Parameter(example = "20", name = "사이즈")
                                           @RequestParam(value = "size") int size,
-                                          @Parameter(example = "조회수순(blogViews) / 좋아요순(blogScraps) / 최신순(newest) = 기본값", name = "정렬")
+                                          @Parameter(example = "조회수순(views) / 좋아요순(scraps) / 최신순(newest) = 기본값", name = "정렬")
                                           @RequestParam(value = "sort") String sort) {
 
         return blogRecipeService.findBlogRecipesByKeyword(user, keyword, startAfter, size, sort);

--- a/src/main/java/com/recipe/app/src/recipe/api/RecipeController.java
+++ b/src/main/java/com/recipe/app/src/recipe/api/RecipeController.java
@@ -44,7 +44,7 @@ public class RecipeController {
                                       @RequestParam(value = "startAfter") long startAfter,
                                       @Parameter(example = "20", name = "사이즈")
                                       @RequestParam(value = "size") int size,
-                                      @Parameter(example = "조회수순(recipeViews) / 좋아요순(recipeScraps) / 최신순(newest) = 기본값", name = "정렬")
+                                      @Parameter(example = "조회수순(views) / 좋아요순(scraps) / 최신순(newest) = 기본값", name = "정렬")
                                       @RequestParam(value = "sort") String sort) {
 
         return recipeSearchService.findRecipesByKeywordOrderBy(user, keyword, startAfter, size, sort);

--- a/src/main/java/com/recipe/app/src/recipe/api/YoutubeRecipeController.java
+++ b/src/main/java/com/recipe/app/src/recipe/api/YoutubeRecipeController.java
@@ -38,7 +38,7 @@ public class YoutubeRecipeController {
                                              @RequestParam(value = "startAfter") long startAfter,
                                              @Parameter(example = "20", name = "사이즈")
                                              @RequestParam(value = "size") int size,
-                                             @Parameter(example = "조회수순(youtubeViews) / 좋아요순(youtubeScraps) / 최신순(newest) = 기본값", name = "정렬")
+                                             @Parameter(example = "조회수순(views) / 좋아요순(scraps) / 최신순(newest) = 기본값", name = "정렬")
                                              @RequestParam(value = "sort") String sort) throws IOException {
 
         return youtubeRecipeService.findYoutubeRecipesByKeyword(user, keyword, startAfter, size, sort);

--- a/src/main/java/com/recipe/app/src/recipe/application/RecipeSearchService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/RecipeSearchService.java
@@ -45,9 +45,9 @@ public class RecipeSearchService {
         long totalCnt = recipeRepository.countByKeyword(keyword);
 
         List<Recipe> recipes;
-        if (sort.equals("recipeScraps")) {
+        if (sort.equals("scraps")) {
             recipes = findByKeywordOrderByRecipeScrapCnt(keyword, lastRecipeId, size);
-        } else if (sort.equals("recipeViews")) {
+        } else if (sort.equals("views")) {
             recipes = findByKeywordOrderByRecipeViewCnt(keyword, lastRecipeId, size);
         } else {
             recipes = findByKeywordOrderByCreatedAt(keyword, lastRecipeId, size);

--- a/src/main/java/com/recipe/app/src/recipe/application/blog/BlogRecipeService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/blog/BlogRecipeService.java
@@ -55,9 +55,9 @@ public class BlogRecipeService {
     @Transactional(readOnly = true)
     public List<BlogRecipe> findByKeywordOrderBy(String keyword, long lastBlogRecipeId, int size, String sort) {
 
-        if (sort.equals("blogScraps")) {
+        if (sort.equals("scraps")) {
             return findByKeywordOrderByBlogScrapCnt(keyword, lastBlogRecipeId, size);
-        } else if (sort.equals("blogViews")) {
+        } else if (sort.equals("views")) {
             return findByKeywordOrderByBlogViewCnt(keyword, lastBlogRecipeId, size);
         } else {
             return findByKeywordOrderByPublishedAt(keyword, lastBlogRecipeId, size);

--- a/src/main/java/com/recipe/app/src/recipe/application/youtube/YoutubeRecipeService.java
+++ b/src/main/java/com/recipe/app/src/recipe/application/youtube/YoutubeRecipeService.java
@@ -54,9 +54,9 @@ public class YoutubeRecipeService {
     @Transactional(readOnly = true)
     public List<YoutubeRecipe> findByKeywordOrderBy(String keyword, long lastYoutubeRecipeId, int size, String sort) {
 
-        if (sort.equals("youtubeScraps")) {
+        if (sort.equals("scraps")) {
             return findByKeywordOrderByYoutubeScrapCnt(keyword, lastYoutubeRecipeId, size);
-        } else if (sort.equals("youtubeViews")) {
+        } else if (sort.equals("views")) {
             return findByKeywordOrderByYoutubeViewCnt(keyword, lastYoutubeRecipeId, size);
         } else {
             return findByKeywordOrderByPostDate(keyword, lastYoutubeRecipeId, size);

--- a/src/test/groovy/com/recipe/app/src/recipe/application/RecipeSearchServiceTest.groovy
+++ b/src/test/groovy/com/recipe/app/src/recipe/application/RecipeSearchServiceTest.groovy
@@ -44,7 +44,7 @@ class RecipeSearchServiceTest extends Specification {
         String keyword = "테스트"
         long lastRecipeId = 0
         int size = 10
-        String sort = "recipeScraps"
+        String sort = "scraps"
 
         recipeRepository.countByKeyword(keyword) >> 2
 
@@ -118,7 +118,7 @@ class RecipeSearchServiceTest extends Specification {
         String keyword = "테스트"
         long lastRecipeId = 0
         int size = 10
-        String sort = "recipeViews"
+        String sort = "views"
 
         recipeRepository.countByKeyword(keyword) >> 2
 

--- a/src/test/groovy/com/recipe/app/src/recipe/application/blog/BlogRecipeServiceTest.groovy
+++ b/src/test/groovy/com/recipe/app/src/recipe/application/blog/BlogRecipeServiceTest.groovy
@@ -32,7 +32,7 @@ class BlogRecipeServiceTest extends Specification {
         String keyword = "테스트"
         long lastBlogRecipeId = 0
         int size = 2
-        String sort = "blogScraps"
+        String sort = "scraps"
 
         blogRecipeRepository.countByKeyword(keyword) >> 20
 
@@ -102,7 +102,7 @@ class BlogRecipeServiceTest extends Specification {
         String keyword = "테스트"
         long lastBlogRecipeId = 0
         int size = 2
-        String sort = "blogViews"
+        String sort = "views"
 
         blogRecipeRepository.countByKeyword(keyword) >> 20
 

--- a/src/test/groovy/com/recipe/app/src/recipe/application/youtube/YoutubeRecipeServiceTest.groovy
+++ b/src/test/groovy/com/recipe/app/src/recipe/application/youtube/YoutubeRecipeServiceTest.groovy
@@ -33,7 +33,7 @@ class YoutubeRecipeServiceTest extends Specification {
         String keyword = "테스트"
         long lastYoutubeRecipeId = 0
         int size = 2
-        String sort = "youtubeScraps"
+        String sort = "scraps"
 
         youtubeRecipeRepository.countByKeyword(keyword) >> 20
 
@@ -103,7 +103,7 @@ class YoutubeRecipeServiceTest extends Specification {
         String keyword = "테스트"
         long lastYoutubeRecipeId = 0
         int size = 2
-        String sort = "youtubeViews"
+        String sort = "views"
 
         youtubeRecipeRepository.countByKeyword(keyword) >> 20
 


### PR DESCRIPTION
## Issue Number

-

## Summary

- 블로그/유튜브/공공 레시피 조회 시 정렬값 통일

## Describe

- newest: 최신순
- scraps: 좋아요순
- views: 조회순

## ETC

-
