### PR TITLE
fix: 탈퇴한 사용자가 다시 로그인하지 못하도록 소프트 삭제 검증 추가

### DIFF
--- a/src/main/java/com/recipe/app/src/user/application/UserService.java
+++ b/src/main/java/com/recipe/app/src/user/application/UserService.java
@@ -118,7 +118,7 @@ public class UserService {
 
     private User create(User user) {
 
-        return userRepository.findBySocialId(user.getSocialId())
+        return userRepository.findBySocialIdAndDeletedAtIsNull(user.getSocialId())
                 .orElseGet(() -> userRepository.save(user));
     }
 

--- a/src/main/java/com/recipe/app/src/user/infra/UserRepository.java
+++ b/src/main/java/com/recipe/app/src/user/infra/UserRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findBySocialId(String socialId);
+    Optional<User> findBySocialIdAndDeletedAtIsNull(String socialId);
 }

--- a/src/test/groovy/com/recipe/app/src/user/application/UserServiceTest.groovy
+++ b/src/test/groovy/com/recipe/app/src/user/application/UserServiceTest.groovy
@@ -85,7 +85,7 @@ class UserServiceTest extends Specification {
 
         userAuthClientService.getUserByNaverAuthInfo(request) >> user
 
-        userRepository.findBySocialId(user.socialId) >> Optional.of(user)
+        userRepository.findBySocialIdAndDeletedAtIsNull(user.socialId) >> Optional.of(user)
 
         String accessToken = "access_token"
         String refreshToken = "refresh_token"
@@ -141,7 +141,7 @@ class UserServiceTest extends Specification {
 
         userAuthClientService.getUserByKakaoAuthInfo(request) >> user
 
-        userRepository.findBySocialId(user.socialId) >> Optional.of(user)
+        userRepository.findBySocialIdAndDeletedAtIsNull(user.socialId) >> Optional.of(user)
 
         String accessToken = "access_token"
         String refreshToken = "refresh_token"
@@ -197,7 +197,7 @@ class UserServiceTest extends Specification {
 
         userAuthClientService.getUserByGoogleAuthInfo(request) >> user
 
-        userRepository.findBySocialId(user.socialId) >> Optional.of(user)
+        userRepository.findBySocialIdAndDeletedAtIsNull(user.socialId) >> Optional.of(user)
 
         String accessToken = "access_token"
         String refreshToken = "refresh_token"


### PR DESCRIPTION
## Summary

- 탈퇴한 사용자가 다시 로그인하지 못하도록 소프트 삭제 검증 추가

## Describe

UserRepository의 findBySocialId() 메서드를 findBySocialIdAndDeletedAtIsNull()로 변경하여 deletedAt이 null인 (탈퇴하지 않은) 사용자만 조회되도록 수정했습니다.
이를 통해 탈퇴한 사용자가 다시 로그인하는 것을 방지합니다.

- UserRepository: JPA 메서드 네이밍으로 soft delete 검증 추가
- UserService.create(): 업데이트된 리포지토리 메서드 호출
- UserServiceTest: 네이버, 카카오, 구글 로그인 테스트 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

